### PR TITLE
Refactor metadata

### DIFF
--- a/examples/01-simple.rego
+++ b/examples/01-simple.rego
@@ -5,6 +5,10 @@
 #
 package rules.snyk_001.tf
 
+# Rules can set metadata in the `metadata` assignment.  This is typically
+# imported from a JSON file, like here:
+metadata = data.rules.snyk_001.metadata
+
 # Simple rules must assign `resource_type`.  All resources of this type will
 # be subject to this rule.
 resource_type = "aws_s3_bucket"

--- a/examples/07-missing.rego
+++ b/examples/07-missing.rego
@@ -6,6 +6,8 @@
 # `include_global_service_events` set to true.
 package rules.snyk_007.tf
 
+metadata = data.rules.snyk_007.metadata
+
 # Not all cloudtrails are relevant for this validation.  If a specific trail
 # doesn't have this set, it is not necessarily noncompliant: it could be
 # unrelated.  This is why we just grab the relevant ones here.

--- a/examples/metadata/rules/snyk_007/metadata.json
+++ b/examples/metadata/rules/snyk_007/metadata.json
@@ -1,0 +1,5 @@
+{
+    "metadata": {
+        "description": "This is rule 7"
+    }
+}

--- a/pkg/upe/upe.go
+++ b/pkg/upe/upe.go
@@ -98,12 +98,11 @@ func (upe *Upe) IterateRules(ctx context.Context) []RuleInfo {
 					}
 
 					// Load metadata, ignoring errors for now.
-					parent := pkg[0 : len(pkg)-1]
 					upe.Eval(
 						ctx,
 						nil,
 						struct{}{},
-						parent.Append(ast.StringTerm("metadata")),
+						pkg.Append(ast.StringTerm("metadata")),
 						&rule.Metadata,
 					)
 


### PR DESCRIPTION
Rather than automatically grabbing metadata from the parent, ask rules to set it explicitly.

This makes it easier to include metadata in rules when we need to (e.g. for custom rules).