### PR TITLE
Remove IAC group from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jaspervdj-snyk @jason-snyk @snyk/group-infrastructure-as-code
+* @jaspervdj-snyk @jason-snyk


### PR DESCRIPTION
While we obviously still work for them, I imagine it's annoying for them to keep
getting assigned to mostly unrelated PR reviews.