### PR TITLE
Improve messaging for non-policy mods in data.rules

### DIFF
--- a/pkg/policy/base.go
+++ b/pkg/policy/base.go
@@ -148,10 +148,7 @@ func NewBasePolicy(module *ast.Module) (*BasePolicy, error) {
 		}
 	}
 	if judgement.name == "" {
-		return nil, fmt.Errorf(
-			"Policy %s did not contain any judgement rules.",
-			module.Package.Path.String(),
-		)
+		return nil, nil
 	}
 	return &BasePolicy{
 		module:           module,

--- a/pkg/policy/factory.go
+++ b/pkg/policy/factory.go
@@ -11,6 +11,9 @@ func PolicyFactory(module *ast.Module) (Policy, error) {
 	if err != nil {
 		return nil, err
 	}
+	if base == nil {
+		return nil, nil
+	}
 	if base.resourceType() == multipleResourceType {
 		switch base.judgementRule.name {
 		case "deny":

--- a/pkg/upe/consumer.go
+++ b/pkg/upe/consumer.go
@@ -44,8 +44,12 @@ func (c *PolicyConsumer) Module(
 			c.logger.
 				WithField(logging.PATH, path).
 				WithField(logging.ERROR, err.Error()).
-				Debug(ctx, "Unable to parse as a policy")
+				Warn(ctx, "Error while parsing policy. It will still be loaded and accessible via data.")
 			return nil
+		} else if p == nil {
+			c.logger.
+				WithField(logging.PATH, path).
+				Debug(ctx, "Module did not contain a policy. It will still be loaded and accessible via data.")
 		} else {
 			c.Policies = append(c.Policies, p)
 		}


### PR DESCRIPTION
This PR changes the way that we handle modules without policies in the `data.rules` package. Before, we were using the error handling path to communicate that a policy did not contain any judgements. With this PR, the debug log message for non-policy modules (e.g. test fixtures) will look like:

```
9:11AM DBG Module did not contain a policy. It will still be loaded and accessible via data. path=.scratch/no-policy/main.rego
```
