### PR TITLE
Update policy metadata structure

### DIFF
--- a/docs/policy_spec.md
+++ b/docs/policy_spec.md
@@ -153,19 +153,16 @@ metadata := {
     ],
     "service_group": "S3",
     "controls": {
-        "CIS-AWS_v1.3.0": [
-            "CIS-AWS_v1.3.0_5.1",
-            "CIS-AWS_v1.3.0_5.2"
-        ],
-        "CIS-AWS_v1.4.0": [
-            "CIS-AWS_v1.4.0_6.7"
-        ]
+        "CIS-AWS": {
+          "v1.3.0": [
+            "5.1",
+            "5.2"
+          ],
+          "v1.4.0": [
+            "6.7"
+          ]
+        }
     },
-    "rule_sets": [
-        "CIS-AWS_v1.3.0",
-        "CIS-AWS_v1.4.0",
-        "2931f772-5599-4aed-9e2d-b5ed9a2d7aa3"
-    ],
     "severity": "Critical"
 }
 ```

--- a/pkg/models/model_rule_results.go
+++ b/pkg/models/model_rule_results.go
@@ -18,10 +18,8 @@ type RuleResults struct {
 	Description string `json:"description,omitempty"`
 	// A markdown formatted string containing useful links
 	References string `json:"references,omitempty"`
-	// A map of rule set ID to a list of control tags
-	Controls map[string][]string `json:"controls,omitempty"`
-	// A list of rule set IDs associated with this rule
-	RuleSets []string `json:"rule_sets,omitempty"`
+	// A map of rule set ID to a map of versions to a list of control IDs
+	Controls map[string]map[string][]string `json:"controls,omitempty"`
 	// A list of resource types that the rule uses.
 	ResourceTypes []string     `json:"resource_types,omitempty"`
 	Results       []RuleResult `json:"results"`

--- a/pkg/policy/base.go
+++ b/pkg/policy/base.go
@@ -89,16 +89,16 @@ func (i *ruleInfo) hasKey() bool {
 }
 
 type Metadata struct {
-	ID           string              `json:"id"`
-	Title        string              `json:"title"`
-	Description  string              `json:"description"`
-	Remediation  map[string]string   `json:"remediation"`
-	References   string              `json:"references"` // TODO: Should this be a dict, similar to a bibliography?
-	Categories   []string            `json:"categories"`
-	ServiceGroup string              `json:"service_group"` // TODO: Should this be a []string?
-	Controls     map[string][]string `json:"controls"`
-	RuleSets     []string            `json:"rule_sets"`
-	Severity     string              `json:"severity"`
+	ID           string                         `json:"id"`
+	Title        string                         `json:"title"`
+	Description  string                         `json:"description"`
+	Remediation  map[string]string              `json:"remediation"`
+	References   string                         `json:"references"`
+	Category     string                         `json:"category"`
+	Tags         []string                       `json:"tags"`
+	ServiceGroup string                         `json:"service_group"`
+	Controls     map[string]map[string][]string `json:"controls"`
+	Severity     string                         `json:"severity"`
 }
 
 // BasePolicy implements functionality that is shared between different concrete
@@ -229,8 +229,8 @@ func (p *BasePolicy) Metadata(
 			Description: d.Description,
 		}
 		if d.Custom != nil {
-			m.Controls = d.Custom.Controls
-			m.RuleSets = d.Custom.Families
+			// It's not necessary to process controls here, because this path is only
+			// for backwards compatibility with custom rules.
 			m.Severity = d.Custom.Severity
 		}
 	default:

--- a/pkg/policy/multi.go
+++ b/pkg/policy/multi.go
@@ -46,6 +46,7 @@ func (p *MultiResourcePolicy) Eval(
 	output.Title = metadata.Title
 	output.Description = metadata.Description
 	output.Controls = metadata.Controls
+	output.References = metadata.References
 	opts := append(
 		options.RegoOptions,
 		rego.Query(p.judgementRule.query()),

--- a/pkg/policy/single.go
+++ b/pkg/policy/single.go
@@ -48,6 +48,7 @@ func (p *SingleResourcePolicy) Eval(
 	output.Title = metadata.Title
 	output.Description = metadata.Description
 	output.Controls = metadata.Controls
+	output.References = metadata.References
 	opts := append(
 		options.RegoOptions,
 		rego.Query(p.judgementRule.query()),

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -166,16 +166,13 @@ components:
           description: A markdown formatted string containing useful links
         controls:
           type: object
-          description: A map of rule set ID to a list of control tags
+          description: A map of rule set ID to a map of versions to a list of control IDs
           additionalProperties:
-            type: array
-            items:
-              type: string
-        rule_sets:
-          type: array
-          description: A list of rule set IDs associated with this rule
-          items:
-            type: string
+            type: object
+            additionalProperties:
+              type: array
+              items:
+                type: string
         resource_types:
           type: array
           description: A list of resource types that the rule uses.


### PR DESCRIPTION
This PR updates the policy metadata structure to reflect the decisions we've made in the design docs and in design discussions:

* `controls` are now structured to look like:
```json
    "controls": {
        "CIS-AWS": {
          "v1.3.0": [
            "5.1",
            "5.2"
          ],
          "v1.4.0": [
            "6.7"
          ]
        }
    }
```
* we've dropped `rule_sets` for the time being

I also made the decision not to worry about transforming the Fugue `controls` format in the backwards-compatibility code, because `controls` is only a concern for custom rules that were stored in Fugue. And with those rules, we were programmatically generating the `__rego__metadoc__` rule anyway, so the real solution would be to generate that block differently rather than doing the transformation in UPE.