### PR TITLE
Fix a crash when no ResourcesResolvers configured

### DIFF
--- a/changes/unreleased/Fixed-20220622-085201.yaml
+++ b/changes/unreleased/Fixed-20220622-085201.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: crash when no ResourcesResolvers configured
+time: 2022-06-22T08:52:01.757443+01:00

--- a/pkg/policy/api.go
+++ b/pkg/policy/api.go
@@ -271,13 +271,15 @@ func NewBuiltins(input *models.State, resourcesResolver ResourcesResolver) *Buil
 	// all queried resources are returned by inputResourceTypes
 	inputResolver := newInputResolver(input)
 	resourcesByType := &resourcesByType{input: input, calledWith: inputResolver.calledWith}
+	resolver := ResourcesResolver(inputResolver.resolve)
+	if resourcesResolver != nil {
+		resolver = resolver.Or(resourcesResolver)
+	}
 
 	return &Builtins{
 		resourcesQueried: inputResolver.calledWith,
 		funcs: []builtin{
-			&Query{
-				ResourcesResolver: ResourcesResolver(inputResolver.resolve).Or(resourcesResolver),
-			},
+			&Query{ResourcesResolver: resolver},
 			&currentInputType{input},
 			&inputResourceTypes{input},
 			resourcesByType,


### PR DESCRIPTION
We accidentally broke this case when iterating on https://github.com/snyk/unified-policy-engine/pull/39