### PR TITLE
Allow OPA tests to be filtered by regex

### DIFF
--- a/changes/unreleased/Added-20220623-090227.yaml
+++ b/changes/unreleased/Added-20220623-090227.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: allow tests to be filtered by name
+time: 2022-06-23T09:02:27.975273+01:00


### PR DESCRIPTION
Tester exits with non-zero status when no tests found, as a guard
against malformed filters.

This could be useful when iterating on a single policy.