### PR TITLE
Cleanup unreleased changes during release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ release:
 	test $(VERSION)
 	changie batch $(VERSION)
 	changie merge
-	git add changes/$(VERSION).md CHANGELOG.md
+	git add changes CHANGELOG.md
 	git diff --staged
 	@echo -n "Are you sure? [y/N] " && read ans && [ $${ans:-N} == y ]
 	git commit -m "Bump version to $(VERSION)"

--- a/changes/unreleased/Fixed-20220621-180252.yaml
+++ b/changes/unreleased/Fixed-20220621-180252.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: links in query / ResourcesResolver docs
-time: 2022-06-21T18:02:52.79336+01:00

--- a/changes/unreleased/Fixed-20220622-085201.yaml
+++ b/changes/unreleased/Fixed-20220622-085201.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: crash when no ResourcesResolvers configured
-time: 2022-06-22T08:52:01.757443+01:00

--- a/changes/unreleased/Fixed-20220622-091111.yaml
+++ b/changes/unreleased/Fixed-20220622-091111.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: Premature exits in commands
-time: 2022-06-22T09:11:11.853434-04:00


### PR DESCRIPTION
This PR makes it so the entire `changes` directory gets committed during the release process. `changie` deletes the contents of `changes/unreleased` when you run `changie batch`. We need to commit those deletions so that those change log entries don't get duplicated in the next release.