### PR TITLE
[CLOUD-299] Raise errors from builtins

### DIFF
--- a/changes/unreleased/Fixed-20220628-143651.yaml
+++ b/changes/unreleased/Fixed-20220628-143651.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: errors from builtins not being raised
+time: 2022-06-28T14:36:51.021437-04:00

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -138,6 +138,7 @@ func (e *Engine) Eval(ctx context.Context, options *EvalOptions) *models.Results
 	regoOptions := []func(*rego.Rego){
 		rego.Compiler(e.compiler),
 		rego.Store(e.store),
+		rego.StrictBuiltinErrors(true),
 	}
 	policies := e.policies
 	if !e.runAllRules {


### PR DESCRIPTION
This PR enables the "strict builtin errors" OPA option in `Engine`. Without this option, errors from custom builtins do not bubble up. We're already setting this option in `policy-engine repl`, although we're not using the custom builtins there yet. There's not an equivalent option on `tester.Runner`, but I suspect that it's the default behavior. We'll be able to test it once we start using custom builtins in `policy-engine test`.