### PR TITLE
Fix issues with identical IDs for tfstate resources

### DIFF
--- a/changes/unreleased/Fixed-20220705-101649.yaml
+++ b/changes/unreleased/Fixed-20220705-101649.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Avoid overlapping resource IDs in tfstate loader
+time: 2022-07-05T10:16:49.09936177+02:00

--- a/pkg/hcl_interpreter/hcl_interpreter.go
+++ b/pkg/hcl_interpreter/hcl_interpreter.go
@@ -297,8 +297,8 @@ func (v *Evaluation) evaluate() error {
 	return nil
 }
 
-func (v *Evaluation) Resources() map[string]models.ResourceState {
-	input := map[string]models.ResourceState{}
+func (v *Evaluation) Resources() []models.ResourceState {
+	resources := []models.ResourceState{}
 
 	for resourceKey, resource := range v.Analysis.Resources {
 		resourceName, err := StringToFullName(resourceKey)
@@ -342,13 +342,13 @@ func (v *Evaluation) Resources() map[string]models.ResourceState {
 		}
 
 		// TODO: Support tags again: PopulateTags(input[resourceKey])
-		input[resourceKey] = models.ResourceState{
+		resources = append(resources, models.ResourceState{
 			Id:           resourceKey,
 			ResourceType: resourceType,
 			Attributes:   attrs,
 			Meta:         meta,
-		}
+		})
 	}
 
-	return input
+	return resources
 }

--- a/pkg/input/adapter.go
+++ b/pkg/input/adapter.go
@@ -47,14 +47,14 @@ func toState(
 }
 
 func groupResourcesByType(
-	resources map[string]models.ResourceState,
+	resources []models.ResourceState,
 ) map[string]map[string]models.ResourceState {
 	byType := map[string]map[string]models.ResourceState{}
-	for key, resource := range resources {
+	for _, resource := range resources {
 		if _, ok := byType[resource.ResourceType]; !ok {
 			byType[resource.ResourceType] = map[string]models.ResourceState{}
 		}
-		byType[resource.ResourceType][key] = resource
+		byType[resource.ResourceType][resource.Id] = resource
 	}
 	return byType
 }

--- a/pkg/input/arm.go
+++ b/pkg/input/arm.go
@@ -90,11 +90,11 @@ func (l *armConfiguration) ToState() models.State {
 	}
 
 	// Process resources
-	resources := map[string]models.ResourceState{}
-	for k, d := range l.discovered {
+	resources := []models.ResourceState{}
+	for _, d := range l.discovered {
 		resource := d.process(&refResolver)
 		resource.Namespace = l.path
-		resources[k] = resource
+		resources = append(resources, resource)
 	}
 
 	return models.State{

--- a/pkg/input/golden_test/tfstate/ids-01.json
+++ b/pkg/input/golden_test/tfstate/ids-01.json
@@ -1,0 +1,150 @@
+{
+  "format": "",
+  "format_version": "",
+  "input_type": "tf_state",
+  "environment_provider": "aws",
+  "resources": {
+    "aws_s3_bucket": {
+      "terraform-20220704200619858700000001": {
+        "id": "terraform-20220704200619858700000001",
+        "resource_type": "aws_s3_bucket",
+        "namespace": "aws",
+        "meta": {
+          "tfstate": {
+            "name": "bucket1"
+          }
+        },
+        "attributes": {
+          "acceleration_status": "",
+          "acl": null,
+          "arn": "arn:aws:s3:::terraform-20220704200619858700000001",
+          "bucket": "terraform-20220704200619858700000001",
+          "bucket_domain_name": "terraform-20220704200619858700000001.s3.amazonaws.com",
+          "bucket_prefix": null,
+          "bucket_regional_domain_name": "terraform-20220704200619858700000001.s3.us-west-1.amazonaws.com",
+          "cors_rule": [],
+          "force_destroy": true,
+          "grant": [
+            {
+              "id": "d5c48f20001a6ee7be6d75e69fe2da57d4c273b03ac318bd3d5526018c47ecb5",
+              "permissions": [
+                "FULL_CONTROL"
+              ],
+              "type": "CanonicalUser",
+              "uri": ""
+            }
+          ],
+          "hosted_zone_id": "Z2F56UZL2M1ACD",
+          "id": "terraform-20220704200619858700000001",
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "object_lock_enabled": false,
+          "policy": "",
+          "region": "us-west-1",
+          "replication_configuration": [],
+          "request_payer": "BucketOwner",
+          "server_side_encryption_configuration": [],
+          "tags": null,
+          "tags_all": {},
+          "versioning": [
+            {
+              "enabled": false,
+              "mfa_delete": false
+            }
+          ],
+          "website": [],
+          "website_domain": null,
+          "website_endpoint": null
+        }
+      }
+    },
+    "aws_s3_bucket_acl": {
+      "terraform-20220704200619858700000001,log-delivery-write": {
+        "id": "terraform-20220704200619858700000001,log-delivery-write",
+        "resource_type": "aws_s3_bucket_acl",
+        "namespace": "aws",
+        "meta": {
+          "tfstate": {
+            "name": "acl1"
+          }
+        },
+        "attributes": {
+          "access_control_policy": [
+            {
+              "grant": [
+                {
+                  "grantee": [
+                    {
+                      "display_name": "",
+                      "email_address": "",
+                      "id": "",
+                      "type": "Group",
+                      "uri": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+                    }
+                  ],
+                  "permission": "READ_ACP"
+                },
+                {
+                  "grantee": [
+                    {
+                      "display_name": "",
+                      "email_address": "",
+                      "id": "",
+                      "type": "Group",
+                      "uri": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+                    }
+                  ],
+                  "permission": "WRITE"
+                },
+                {
+                  "grantee": [
+                    {
+                      "display_name": "jasper",
+                      "email_address": "",
+                      "id": "d5c48f20001a6ee7be6d75e69fe2da57d4c273b03ac318bd3d5526018c47ecb5",
+                      "type": "CanonicalUser",
+                      "uri": ""
+                    }
+                  ],
+                  "permission": "FULL_CONTROL"
+                }
+              ],
+              "owner": [
+                {
+                  "display_name": "jasper",
+                  "id": "d5c48f20001a6ee7be6d75e69fe2da57d4c273b03ac318bd3d5526018c47ecb5"
+                }
+              ]
+            }
+          ],
+          "acl": "log-delivery-write",
+          "bucket": "terraform-20220704200619858700000001",
+          "expected_bucket_owner": "",
+          "id": "terraform-20220704200619858700000001,log-delivery-write"
+        }
+      }
+    },
+    "aws_s3_bucket_logging": {
+      "terraform-20220704200619858700000001": {
+        "id": "terraform-20220704200619858700000001",
+        "resource_type": "aws_s3_bucket_logging",
+        "namespace": "aws",
+        "meta": {
+          "tfstate": {
+            "name": "logging1"
+          }
+        },
+        "attributes": {
+          "bucket": "terraform-20220704200619858700000001",
+          "expected_bucket_owner": "",
+          "id": "terraform-20220704200619858700000001",
+          "target_bucket": "terraform-20220704200619858700000001",
+          "target_grant": [],
+          "target_prefix": "log/"
+        }
+      }
+    }
+  },
+  "scope": null
+}

--- a/pkg/input/golden_test/tfstate/ids-01/plan.json
+++ b/pkg/input/golden_test/tfstate/ids-01/plan.json
@@ -1,0 +1,159 @@
+{
+  "version": 4,
+  "terraform_version": "1.1.9",
+  "serial": 4,
+  "lineage": "47ef3101-a40c-7149-9921-118c3daaf6bb",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "bucket1",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "acceleration_status": "",
+            "acl": null,
+            "arn": "arn:aws:s3:::terraform-20220704200619858700000001",
+            "bucket": "terraform-20220704200619858700000001",
+            "bucket_domain_name": "terraform-20220704200619858700000001.s3.amazonaws.com",
+            "bucket_prefix": null,
+            "bucket_regional_domain_name": "terraform-20220704200619858700000001.s3.us-west-1.amazonaws.com",
+            "cors_rule": [],
+            "force_destroy": true,
+            "grant": [
+              {
+                "id": "d5c48f20001a6ee7be6d75e69fe2da57d4c273b03ac318bd3d5526018c47ecb5",
+                "permissions": [
+                  "FULL_CONTROL"
+                ],
+                "type": "CanonicalUser",
+                "uri": ""
+              }
+            ],
+            "hosted_zone_id": "Z2F56UZL2M1ACD",
+            "id": "terraform-20220704200619858700000001",
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "object_lock_enabled": false,
+            "policy": "",
+            "region": "us-west-1",
+            "replication_configuration": [],
+            "request_payer": "BucketOwner",
+            "server_side_encryption_configuration": [],
+            "tags": null,
+            "tags_all": {},
+            "versioning": [
+              {
+                "enabled": false,
+                "mfa_delete": false
+              }
+            ],
+            "website": [],
+            "website_domain": null,
+            "website_endpoint": null
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_bucket_acl",
+      "name": "acl1",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "access_control_policy": [
+              {
+                "grant": [
+                  {
+                    "grantee": [
+                      {
+                        "display_name": "",
+                        "email_address": "",
+                        "id": "",
+                        "type": "Group",
+                        "uri": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+                      }
+                    ],
+                    "permission": "READ_ACP"
+                  },
+                  {
+                    "grantee": [
+                      {
+                        "display_name": "",
+                        "email_address": "",
+                        "id": "",
+                        "type": "Group",
+                        "uri": "http://acs.amazonaws.com/groups/s3/LogDelivery"
+                      }
+                    ],
+                    "permission": "WRITE"
+                  },
+                  {
+                    "grantee": [
+                      {
+                        "display_name": "jasper",
+                        "email_address": "",
+                        "id": "d5c48f20001a6ee7be6d75e69fe2da57d4c273b03ac318bd3d5526018c47ecb5",
+                        "type": "CanonicalUser",
+                        "uri": ""
+                      }
+                    ],
+                    "permission": "FULL_CONTROL"
+                  }
+                ],
+                "owner": [
+                  {
+                    "display_name": "jasper",
+                    "id": "d5c48f20001a6ee7be6d75e69fe2da57d4c273b03ac318bd3d5526018c47ecb5"
+                  }
+                ]
+              }
+            ],
+            "acl": "log-delivery-write",
+            "bucket": "terraform-20220704200619858700000001",
+            "expected_bucket_owner": "",
+            "id": "terraform-20220704200619858700000001,log-delivery-write"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_s3_bucket.bucket1"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "aws_s3_bucket_logging",
+      "name": "logging1",
+      "provider": "provider[\"registry.terraform.io/hashicorp/aws\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "bucket": "terraform-20220704200619858700000001",
+            "expected_bucket_owner": "",
+            "id": "terraform-20220704200619858700000001",
+            "target_bucket": "terraform-20220704200619858700000001",
+            "target_grant": [],
+            "target_prefix": "log/"
+          },
+          "sensitive_attributes": [],
+          "private": "bnVsbA==",
+          "dependencies": [
+            "aws_s3_bucket.bucket1"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/input/tf.go
+++ b/pkg/input/tf.go
@@ -124,9 +124,8 @@ func (c *HclConfiguration) ToState() models.State {
 	resources := c.evaluation.Resources()
 
 	namespace := c.moduleTree.FilePath()
-	for k, resource := range resources {
-		resource.Namespace = namespace
-		resources[k] = resource
+	for i := range resources {
+		resources[i].Namespace = namespace
 	}
 
 	return models.State{

--- a/pkg/input/tfplan.go
+++ b/pkg/input/tfplan.go
@@ -395,11 +395,11 @@ func (expr *tfplan_ConfigurationExpression) references(resolve func(string) *str
 }
 
 // Main entry point to convert this to an input state.
-func (plan *tfplan_Plan) resources(resourceNamespace string) map[string]models.ResourceState {
+func (plan *tfplan_Plan) resources(resourceNamespace string) []models.ResourceState {
 	// Calculate outputs
 	resolveGlobally := plan.pointers()
 
-	resources := map[string]models.ResourceState{}
+	resources := []models.ResourceState{}
 	plan.visitResources(func(
 		module string,
 		path string,
@@ -485,13 +485,13 @@ func (plan *tfplan_Plan) resources(resourceNamespace string) map[string]models.R
 			resourceType = pvr.Type
 		}
 
-		resources[id] = models.ResourceState{
+		resources = append(resources, models.ResourceState{
 			Id:           id,
 			ResourceType: resourceType,
 			Namespace:    resourceNamespace,
 			Attributes:   attributes,
 			Meta:         meta,
-		}
+		})
 	})
 
 	return resources

--- a/pkg/input/tfstate.go
+++ b/pkg/input/tfstate.go
@@ -85,7 +85,7 @@ func (l *tfstateLoader) Location(attributePath []interface{}) (LocationStack, er
 }
 
 func (l *tfstateLoader) ToState() models.State {
-	resources := map[string]models.ResourceState{}
+	resources := []models.ResourceState{}
 	environmentProvider := ""
 
 	for _, resource := range l.state.Resources {
@@ -120,7 +120,7 @@ func (l *tfstateLoader) ToState() models.State {
 		}
 
 		// Put it all together
-		resources[id] = models.ResourceState{
+		resources = append(resources, models.ResourceState{
 			Id:           id,
 			ResourceType: resource.Type,
 			Namespace:    resourceProvider,
@@ -130,7 +130,7 @@ func (l *tfstateLoader) ToState() models.State {
 					"name": resource.Name,
 				},
 			},
-		}
+		})
 	}
 
 	return models.State{


### PR DESCRIPTION
The IaC team found some issues with overlapping IDs for resources in the tfstate
input.  This PR checks in the offending case, and modifies the helper we were
using to use plain array, which should prevent this going forward (we could use
a ID+namespace+type combinartion if we ever need to, but an array is simpler).