### PR TITLE
input was not being set in repl

### DIFF
--- a/changes/unreleased/Fixed-20220707-173234.yaml
+++ b/changes/unreleased/Fixed-20220707-173234.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: input was not being set in repl
+time: 2022-07-07T17:32:34.668909629+02:00

--- a/cmd/repl.go
+++ b/cmd/repl.go
@@ -56,7 +56,15 @@ var replCmd = &cobra.Command{
 			if err != nil {
 				return err
 			}
-			consumer.DataDocument(ctx, "repl/input/state.json", replInput)
+			consumer.DataDocument(
+				ctx,
+				"repl/input/state.json",
+				map[string]interface{}{
+					"repl": map[string]interface{}{
+						"input": replInput,
+					},
+				},
+			)
 		}
 		if err := data.PureRegoBuiltinsProvider()(ctx, consumer); err != nil {
 			return err


### PR DESCRIPTION
This made functions like `snyk.resources` return empty results.

We changed the behavior of DataDocument in
50782ca5798a71c40f1c70491fbea265edbad5ab, but this change was not propagated to
the call site in the repl.