### PR TITLE
[CTX-237] Configurable mock query() implementation for tests

### DIFF
--- a/changes/unreleased/Added-20220711-143926.yaml
+++ b/changes/unreleased/Added-20220711-143926.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Configurable mock query() implementation for tests
+time: 2022-07-11T14:39:26.499235+01:00

--- a/rego/snyk.rego
+++ b/rego/snyk.rego
@@ -18,3 +18,21 @@ resources(resource_type) = ret {
 input_type := input.input_type
 
 input_resource_types := {rt | input.resources[rt]}
+
+# Stubbable query() implementation for tests.
+# If resources are not found in the input, return a previously-configured stub
+# value.
+# rule_tests.query_returns in https://github.com/snyk/opa-rules configures stub
+# values in the way that this function expects.
+query(q) = ret {
+	from_input := resources(q.resource_type)
+	count(from_input) > 0
+	ret := from_input
+}
+
+query(q) = ret {
+	from_input := resources(q.resource_type)
+	count(from_input) == 0
+	query_str := json.marshal(q)
+	ret := input._query[query_str]
+}


### PR DESCRIPTION
If resources are not found in the input, return a previously-configured
stub value.
rule_tests.query_returns in https://github.com/snyk/opa-rules configures
stub values in the way that this function expects.

https://github.com/snyk/opa-rules/pull/53 contains the test helper that sets up the stub values we expect here.

https://snyksec.atlassian.net/browse/CTX-237