### PR TITLE
Fix panic on retrieving key from nil resource

### DIFF
--- a/changes/unreleased/Added-20220712-151730.yaml
+++ b/changes/unreleased/Added-20220712-151730.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Infer primary resource if there's only one
+time: 2022-07-12T15:17:30.930295624+02:00

--- a/changes/unreleased/Fixed-20220712-151721.yaml
+++ b/changes/unreleased/Fixed-20220712-151721.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: panic on retrieving key from nil resource
+time: 2022-07-12T15:17:21.520642462+02:00

--- a/pkg/policy/base.go
+++ b/pkg/policy/base.go
@@ -353,7 +353,7 @@ func (p *BasePolicy) resources(
 			r[correlation].setPrimaryResource(result.PrimaryResource.Key())
 		}
 		for _, attr := range result.Attributes {
-			r[correlation].addResourceAttribute(result.Resource.Key(), attr)
+			r[correlation].addResourceAttribute(result.GetResource().Key(), attr)
 		}
 	}
 	return r, nil
@@ -451,6 +451,16 @@ func (resource *policyResultResource) Key() ResourceKey {
 
 func (resource *policyResultResource) Correlation() string {
 	return resource.Key().Correlation()
+}
+
+func (result resourcesResult) GetResource() *policyResultResource {
+	if result.Resource != nil {
+		return result.Resource
+	} else if result.PrimaryResource != nil {
+		return result.PrimaryResource
+	} else {
+		return nil
+	}
 }
 
 func (result resourcesResult) GetCorrelation() string {

--- a/pkg/policy/ruleresultbuilder.go
+++ b/pkg/policy/ruleresultbuilder.go
@@ -80,18 +80,35 @@ func (builder *ruleResultBuilder) addResourceAttribute(
 }
 
 func (builder *ruleResultBuilder) toRuleResult() models.RuleResult {
+	// Gather resources.  TODO: sort?
 	resources := []*models.RuleResultResource{}
 	for _, resource := range builder.resources {
 		resources = append(resources, resource)
 	}
-	sort.Strings(builder.messages)
+
+	// Gather messages.
+	messages := make([]string, len(builder.messages))
+	copy(messages, builder.messages)
+	sort.Strings(messages)
+
+	// Infer primary resource.
+	resourceId := builder.resourceId
+	resourceNamespace := builder.resourceNamespace
+	resourceType := builder.resourceType
+	if len(resources) == 1 {
+		resource := resources[0]
+		resourceId = resource.Id
+		resourceNamespace = resource.Namespace
+		resourceType = resource.Type
+	}
+
 	return models.RuleResult{
 		Passed:            builder.passed,
 		Ignored:           builder.ignored,
-		Message:           strings.Join(builder.messages, "\n\n"),
-		ResourceId:        builder.resourceId,
-		ResourceNamespace: builder.resourceNamespace,
-		ResourceType:      builder.resourceType,
+		Message:           strings.Join(messages, "\n\n"),
+		ResourceId:        resourceId,
+		ResourceNamespace: resourceNamespace,
+		ResourceType:      resourceType,
 		Remediation:       builder.remediation,
 		Severity:          builder.severity,
 		Context:           builder.context,


### PR DESCRIPTION
We should pick either `Resource` or `PrimaryResource`, depending on which one
is not `nil`.  This PR adds a new function to facilitate that and switches over
`BasePolicy.resources()`.