### PR TITLE
[CTX-34] [CTX-190] query(): ResourcesResolver fallthrough on empty

### DIFF
--- a/changes/unreleased/Changed-20220713-151009.yaml
+++ b/changes/unreleased/Changed-20220713-151009.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'query(): ResourcesResolver fallthrough on empty'
+time: 2022-07-13T15:10:09.931553+01:00

--- a/pkg/policy/api.go
+++ b/pkg/policy/api.go
@@ -74,7 +74,7 @@ func (l ResourcesResolver) Or(r ResourcesResolver) ResourcesResolver {
 		}
 		result.ScopeFound = result.ScopeFound || lresult.ScopeFound
 		result.Resources = append(result.Resources, lresult.Resources...)
-		if result.ScopeFound {
+		if result.ScopeFound && len(result.Resources) > 0 {
 			return result, nil
 		}
 		rresult, err := r(ctx, req)


### PR DESCRIPTION
When ResourcesResolvers are chained together with `Or`, fallthrough when
the first resolver returns an empty array of resources, even when the
query scope matches the input scope.

This will allow us to write rules such as:

```
deny[info] {
	ebs_volume := ebs_volumes[_]
	volume_encryption_defaults = snyk.query({
		"resource_type": "aws_ebs_encryption_by_default",
		"scope": {
			"cloud": "aws",
			"region": ebs_volume.provider.aws.region,
		},
	})
	count(volume_encryption_defaults) > 0
	volume_encryption_defaults[0].enabled == true
	ebs_volume.encrypted == false
	info := {
		"message": "EBS Volume is not encrypted",
		"resource": ebs_volume,
	}
}
```

That work in IaC, cloud, and "IaC cloud context" scans. In a pure IaC
scan, the config loader could parse statically configured regions from
terraform providers and place them on resources - or use some abstract
placeholder value when no static region is configured, to indicate that
all resources that share that provider, share an AWS region. If an
aws_ebs_encryption_by_default is configured in the same region as
volumes, it can be taken into account.

In a cloud scan, as long as the config loaders insert cloud metadata,
this should also work.

In an "IaC cloud context" scan, when no aws_ebs_encryption_by_default is
configured, the fallthrough behavior introduced by this commit will
ensure that an AWS ResourcesResolver can retrieve the region-specific
default from the cloud.