### PR TITLE
[CTX-75] Add resource query cache

### DIFF
--- a/changes/unreleased/Added-20220801-173404.yaml
+++ b/changes/unreleased/Added-20220801-173404.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Resource query cache
+time: 2022-08-01T17:34:04.3185+01:00

--- a/pkg/policy/api.go
+++ b/pkg/policy/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"embed"
 	"fmt"
+	"time"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
@@ -276,7 +277,7 @@ type Builtins struct {
 	funcs            []builtin
 }
 
-func NewBuiltins(input *models.State, resourcesResolver ResourcesResolver) *Builtins {
+func NewBuiltins(input *models.State, resourcesResolver ResourcesResolver, queryCacheTTL time.Duration) *Builtins {
 	// Share the same calledWith map across resource-querying builtins, so that
 	// all queried resources are returned by inputResourceTypes
 	inputResolver := newInputResolver(input)
@@ -289,7 +290,7 @@ func NewBuiltins(input *models.State, resourcesResolver ResourcesResolver) *Buil
 	return &Builtins{
 		resourcesQueried: inputResolver.calledWith,
 		funcs: []builtin{
-			&Query{ResourcesResolver: resolver},
+			NewQueryBuiltin(resolver, queryCacheTTL),
 			&currentInputType{input},
 			&inputResourceTypes{input},
 			resourcesByType,

--- a/pkg/policy/base.go
+++ b/pkg/policy/base.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
@@ -49,6 +50,7 @@ type EvalOptions struct {
 	InputValue        ast.Value
 	Logger            logging.Logger
 	ResourcesResolver ResourcesResolver
+	QueryCacheTTL     time.Duration
 }
 
 // Policy is an interface that supports all of the ways we want to interact

--- a/pkg/policy/legacyiac.go
+++ b/pkg/policy/legacyiac.go
@@ -44,7 +44,7 @@ func (p *LegacyIaCPolicy) Eval(
 		rego.Query(p.judgementRule.query()),
 		rego.Input(input.Raw()),
 	)
-	builtins := NewBuiltins(options.Input, options.ResourcesResolver)
+	builtins := NewBuiltins(options.Input, options.ResourcesResolver, options.QueryCacheTTL)
 	opts = append(opts, builtins.Rego()...)
 	query, err := rego.New(opts...).PrepareForEval(ctx)
 	if err != nil {

--- a/pkg/policy/multi.go
+++ b/pkg/policy/multi.go
@@ -52,7 +52,7 @@ func (p *MultiResourcePolicy) Eval(
 		rego.Query(p.judgementRule.query()),
 		rego.ParsedInput(options.InputValue),
 	)
-	builtins := NewBuiltins(options.Input, options.ResourcesResolver)
+	builtins := NewBuiltins(options.Input, options.ResourcesResolver, options.QueryCacheTTL)
 	opts = append(opts, builtins.Rego()...)
 	query, err := rego.New(opts...).PrepareForEval(ctx)
 	if err != nil {


### PR DESCRIPTION
Custom ResourcesResolvers may make expensive calls to cloud provider
APIs. It makes sense to cache the results of identical queries for at
least some time.

---

The cache grows unbounded. This likely isn't a huge problem for CLI use-cases (my main motivation for this change), but I'm less sure about the production characteristics of policy-engine on the server side. In a server-side context like Snyk Cloud, I imagined we'd leave this disabled (TTL=0, the default), and perform any caching elsewhere, e.g. in front of resource enumeration APIs, punting this problem.

I've not introduced and size / hit-rate metrics, because policy-engine does not currently have any sort of metrics API as far as I can tell... this is the sort of thing it probably makes sense to gather metrics on, but perhaps this can be done in the future when confronting metrics more generally?