### PR TITLE
fix: Populated rule result description with legacy rule impact

### DIFF
--- a/changes/unreleased/Fixed-20220803-183716.yaml
+++ b/changes/unreleased/Fixed-20220803-183716.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Populated rule result description with legacy rule impact instead of rule issue
+time: 2022-08-03T18:37:16.955634+03:00

--- a/pkg/policy/legacyiac.go
+++ b/pkg/policy/legacyiac.go
@@ -79,7 +79,7 @@ func (r legacyIaCResults) toRuleResults(pkg string, input legacyiac.Input, resou
 			ruleResults = models.RuleResults{
 				Id:          id,
 				Title:       ir.Title,
-				Description: ir.Issue,                          // TODO: Maybe this should be a combination of both impact and issue?
+				Description: ir.Impact,
 				References:  strings.Join(ir.References, "\n"), // TODO: How do we want to transform these?
 				Package_:    pkg,
 			}


### PR DESCRIPTION
#### What this does

- Populates rule result description with legacy rule impact instead of rule issue.

#### Additional information

- [Slack thread](https://snyk.slack.com/archives/C02JMMTLUF9/p1659537271220929?thread_ts=1659282144.282859&cid=C02JMMTLUF9)