### PR TITLE
[CLOUD-578] Fix empty resources not output by CFN parser

### DIFF
--- a/changes/unreleased/Fixed-20220804-092635.yaml
+++ b/changes/unreleased/Fixed-20220804-092635.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Empty resources not being output by CFN parser
+time: 2022-08-04T09:26:35.861121-04:00

--- a/pkg/input/cfn.go
+++ b/pkg/input/cfn.go
@@ -123,9 +123,9 @@ func (tmpl *cfnTemplate) resources() map[string]interface{} {
 		object := map[string]interface{}{}
 		for k, attribute := range properties {
 			object[k] = interfacetricks.TopDownWalk(&resolver, attribute)
-			object["id"] = resourceId
-			object["_type"] = resource.Type
 		}
+		object["id"] = resourceId
+		object["_type"] = resource.Type
 
 		resources[resourceId] = object
 	}

--- a/pkg/input/golden_test/cfn/example-02.json
+++ b/pkg/input/golden_test/cfn/example-02.json
@@ -34,6 +34,26 @@
           "id": "CloudTrailLogging"
         }
       }
+    },
+    "AWS::S3::Bucket": {
+      "LoggingBucket1": {
+        "id": "LoggingBucket1",
+        "resource_type": "AWS::S3::Bucket",
+        "namespace": "golden_test/cfn/example-02/main.yaml",
+        "attributes": {
+          "_type": "AWS::S3::Bucket",
+          "id": "LoggingBucket1"
+        }
+      },
+      "LoggingBucket2": {
+        "id": "LoggingBucket2",
+        "resource_type": "AWS::S3::Bucket",
+        "namespace": "golden_test/cfn/example-02/main.yaml",
+        "attributes": {
+          "_type": "AWS::S3::Bucket",
+          "id": "LoggingBucket2"
+        }
+      }
     }
   },
   "scope": {

--- a/pkg/input/golden_test/cfn/no-props.json
+++ b/pkg/input/golden_test/cfn/no-props.json
@@ -1,0 +1,25 @@
+{
+  "format": "",
+  "format_version": "",
+  "input_type": "cfn",
+  "environment_provider": "iac",
+  "meta": {
+    "filepath": "golden_test/cfn/no-props/template.yaml"
+  },
+  "resources": {
+    "AWS::S3::Bucket": {
+      "CodePipelineArtifactBucket": {
+        "id": "CodePipelineArtifactBucket",
+        "resource_type": "AWS::S3::Bucket",
+        "namespace": "golden_test/cfn/no-props/template.yaml",
+        "attributes": {
+          "_type": "AWS::S3::Bucket",
+          "id": "CodePipelineArtifactBucket"
+        }
+      }
+    }
+  },
+  "scope": {
+    "filepath": "golden_test/cfn/no-props/template.yaml"
+  }
+}

--- a/pkg/input/golden_test/cfn/no-props/template.yaml
+++ b/pkg/input/golden_test/cfn/no-props/template.yaml
@@ -1,0 +1,7 @@
+
+AWSTemplateFormatVersion: 2010-09-09
+Description: Fargate Service
+Resources:
+  CodePipelineArtifactBucket:
+    Type: AWS::S3::Bucket
+    DeletionPolicy: Delete


### PR DESCRIPTION
This PR fixes an issue where empty resources were not being output by the CFN parser. The underlying reason was a misplaced bracket that resulted in us only populating `_type` and `id` if a resource had properties.