### PR TITLE
Disable strict builtins for legacy IaC rules

### DIFF
--- a/changes/unreleased/Changed-20220807-122622.yaml
+++ b/changes/unreleased/Changed-20220807-122622.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Disabled strict builtins for legacy IaC rules
+time: 2022-08-07T12:26:22.502796-04:00


### PR DESCRIPTION
This PR disables "strict builtins" for legacy IaC rules. I've also made it so that errors will make it into the output instead of just being logged. Because legacy IaC rules all share the same package per input type, we aren't able to narrow down which particular rule produced the error. So, we just output the error alongside the package. Like:

```json
[
  {
    "results": null,
    "errors": [
      "/lib/main.rego:131: eval_builtin_error: to_number: strconv.ParseFloat: parsing \"*\": invalid syntax"
    ],
    "package": "data.schemas.arm"
  }
]
```