### PR TITLE
refactor: don't use toState adapter in cfn.go

### DIFF
--- a/changes/unreleased/Changed-20220815-155126.yaml
+++ b/changes/unreleased/Changed-20220815-155126.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: refactored cfn loader to remove toState() use
+time: 2022-08-15T15:51:26.19551656+02:00

--- a/pkg/input/golden_test/cfn/annotate-01.json
+++ b/pkg/input/golden_test/cfn/annotate-01.json
@@ -14,9 +14,7 @@
         "namespace": "golden_test/cfn/annotate-01/main.yaml",
         "meta": {},
         "attributes": {
-          "BucketName": "bar",
-          "_type": "AWS::S3::Bucket",
-          "id": "Bar"
+          "BucketName": "bar"
         }
       },
       "Foo": {
@@ -25,9 +23,7 @@
         "namespace": "golden_test/cfn/annotate-01/main.yaml",
         "meta": {},
         "attributes": {
-          "BucketName": "foo",
-          "_type": "AWS::S3::Bucket",
-          "id": "Foo"
+          "BucketName": "foo"
         }
       }
     }

--- a/pkg/input/golden_test/cfn/example-01.json
+++ b/pkg/input/golden_test/cfn/example-01.json
@@ -14,9 +14,7 @@
         "namespace": "golden_test/cfn/example-01/main.yaml",
         "meta": {},
         "attributes": {
-          "Vpc": "MyVpc",
-          "_type": "SecurityGroupId",
-          "id": "MySecurityGroup"
+          "Vpc": "MyVpc"
         }
       }
     },
@@ -27,9 +25,7 @@
         "namespace": "golden_test/cfn/example-01/main.yaml",
         "meta": {},
         "attributes": {
-          "Name": "bar",
-          "_type": "Vpc",
-          "id": "MyVpc"
+          "Name": "bar"
         }
       }
     }

--- a/pkg/input/golden_test/cfn/example-02.json
+++ b/pkg/input/golden_test/cfn/example-02.json
@@ -30,9 +30,7 @@
           ],
           "IsLogging": true,
           "S3BucketName": "LoggingBucket",
-          "TrailName": "cf-fuguetest-trail",
-          "_type": "AWS::CloudTrail::Trail",
-          "id": "CloudTrailLogging"
+          "TrailName": "cf-fuguetest-trail"
         }
       }
     },
@@ -42,20 +40,14 @@
         "resource_type": "AWS::S3::Bucket",
         "namespace": "golden_test/cfn/example-02/main.yaml",
         "meta": {},
-        "attributes": {
-          "_type": "AWS::S3::Bucket",
-          "id": "LoggingBucket1"
-        }
+        "attributes": {}
       },
       "LoggingBucket2": {
         "id": "LoggingBucket2",
         "resource_type": "AWS::S3::Bucket",
         "namespace": "golden_test/cfn/example-02/main.yaml",
         "meta": {},
-        "attributes": {
-          "_type": "AWS::S3::Bucket",
-          "id": "LoggingBucket2"
-        }
+        "attributes": {}
       }
     }
   },

--- a/pkg/input/golden_test/cfn/example-03.json
+++ b/pkg/input/golden_test/cfn/example-03.json
@@ -32,9 +32,7 @@
           ],
           "IsLogging": true,
           "S3BucketName": "LoggingBucket",
-          "TrailName": "cf-fuguetest-trail",
-          "_type": "AWS::CloudTrail::Trail",
-          "id": "CloudTrailLogging"
+          "TrailName": "cf-fuguetest-trail"
         }
       }
     }

--- a/pkg/input/golden_test/cfn/intrinsics.json
+++ b/pkg/input/golden_test/cfn/intrinsics.json
@@ -29,9 +29,7 @@
           "ManagedPolicyArns": [
             "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
           ],
-          "Path": "/",
-          "_type": "AWS::IAM::Role",
-          "id": "FunctionRole"
+          "Path": "/"
         }
       }
     },
@@ -44,9 +42,7 @@
         "attributes": {
           "FunctionName": "Function5",
           "FunctionVersion": "$LATEST",
-          "Name": "v1",
-          "_type": "AWS::Lambda::Alias",
-          "id": "Function5Alias"
+          "Name": "v1"
         }
       },
       "Function6Alias": {
@@ -57,9 +53,7 @@
         "attributes": {
           "FunctionName": "Function5",
           "FunctionVersion": "$LATEST",
-          "Name": "v1",
-          "_type": "AWS::Lambda::Alias",
-          "id": "Function6Alias"
+          "Name": "v1"
         }
       }
     },
@@ -75,9 +69,7 @@
           },
           "Handler": "index.handler",
           "Role": "FunctionRole",
-          "Runtime": "nodejs12.x",
-          "_type": "AWS::Lambda::Function",
-          "id": "Function"
+          "Runtime": "nodejs12.x"
         }
       },
       "Function2": {
@@ -91,9 +83,7 @@
           },
           "Handler": "index.handler",
           "Role": "FunctionRole",
-          "Runtime": "nodejs12.x",
-          "_type": "AWS::Lambda::Function",
-          "id": "Function2"
+          "Runtime": "nodejs12.x"
         }
       },
       "Function3": {
@@ -107,9 +97,7 @@
           },
           "Handler": "index.handler",
           "Role": "FunctionRole",
-          "Runtime": "nodejs12.x",
-          "_type": "AWS::Lambda::Function",
-          "id": "Function3"
+          "Runtime": "nodejs12.x"
         }
       },
       "Function4": {
@@ -124,9 +112,7 @@
           "FunctionName": "function4",
           "Handler": "index.handler",
           "Role": "FunctionRole",
-          "Runtime": "nodejs12.x",
-          "_type": "AWS::Lambda::Function",
-          "id": "Function4"
+          "Runtime": "nodejs12.x"
         }
       },
       "Function5": {
@@ -141,9 +127,7 @@
           "FunctionName": "function5",
           "Handler": "index.handler",
           "Role": "FunctionRole",
-          "Runtime": "nodejs12.x",
-          "_type": "AWS::Lambda::Function",
-          "id": "Function5"
+          "Runtime": "nodejs12.x"
         }
       },
       "Function6": {
@@ -158,9 +142,7 @@
           "FunctionName": "AWS::Region",
           "Handler": "index.handler",
           "Role": "FunctionRole",
-          "Runtime": "nodejs12.x",
-          "_type": "AWS::Lambda::Function",
-          "id": "Function6"
+          "Runtime": "nodejs12.x"
         }
       }
     },
@@ -173,9 +155,7 @@
         "attributes": {
           "Action": "lambda:InvokeFunction",
           "FunctionName": "Function",
-          "Principal": "*",
-          "_type": "AWS::Lambda::Permission",
-          "id": "FunctionPermissionByArn"
+          "Principal": "*"
         }
       },
       "FunctionPermissionByHardcodedName": {
@@ -186,9 +166,7 @@
         "attributes": {
           "Action": "lambda:InvokeFunction",
           "FunctionName": "function4",
-          "Principal": "*",
-          "_type": "AWS::Lambda::Permission",
-          "id": "FunctionPermissionByHardcodedName"
+          "Principal": "*"
         }
       },
       "FunctionPermissionByHardcodedNameAndAlias": {
@@ -199,9 +177,7 @@
         "attributes": {
           "Action": "lambda:InvokeFunction",
           "FunctionName": "function5:v1",
-          "Principal": "*",
-          "_type": "AWS::Lambda::Permission",
-          "id": "FunctionPermissionByHardcodedNameAndAlias"
+          "Principal": "*"
         }
       },
       "FunctionPermissionByNameAndAliasUsingFunctions": {
@@ -212,9 +188,7 @@
         "attributes": {
           "Action": "lambda:InvokeFunction",
           "FunctionName": "AWS::Region",
-          "Principal": "*",
-          "_type": "AWS::Lambda::Permission",
-          "id": "FunctionPermissionByNameAndAliasUsingFunctions"
+          "Principal": "*"
         }
       },
       "FunctionPermissionByPartialArn": {
@@ -228,9 +202,7 @@
             "AWS::AccountId",
             "Function3"
           ],
-          "Principal": "*",
-          "_type": "AWS::Lambda::Permission",
-          "id": "FunctionPermissionByPartialArn"
+          "Principal": "*"
         }
       },
       "FunctionPermissionByRef": {
@@ -241,9 +213,7 @@
         "attributes": {
           "Action": "lambda:InvokeFunction",
           "FunctionName": "Function2",
-          "Principal": "*",
-          "_type": "AWS::Lambda::Permission",
-          "id": "FunctionPermissionByRef"
+          "Principal": "*"
         }
       }
     }

--- a/pkg/input/golden_test/cfn/json-01.json
+++ b/pkg/input/golden_test/cfn/json-01.json
@@ -14,9 +14,7 @@
         "namespace": "golden_test/cfn/json-01/cfn.json",
         "meta": {},
         "attributes": {
-          "AccessControl": "Private",
-          "_type": "AWS::S3::Bucket",
-          "id": "Bucket1"
+          "AccessControl": "Private"
         }
       },
       "Bucket2": {
@@ -30,9 +28,7 @@
             "BlockPublicAcls": true,
             "IgnorePublicAcls": true,
             "RestrictPublicBuckets": true
-          },
-          "_type": "AWS::S3::Bucket",
-          "id": "Bucket2"
+          }
         }
       }
     }

--- a/pkg/input/golden_test/cfn/no-props.json
+++ b/pkg/input/golden_test/cfn/no-props.json
@@ -13,10 +13,7 @@
         "resource_type": "AWS::S3::Bucket",
         "namespace": "golden_test/cfn/no-props/template.yaml",
         "meta": {},
-        "attributes": {
-          "_type": "AWS::S3::Bucket",
-          "id": "CodePipelineArtifactBucket"
-        }
+        "attributes": {}
       }
     }
   },

--- a/pkg/input/golden_test/cfn/params-01.json
+++ b/pkg/input/golden_test/cfn/params-01.json
@@ -15,9 +15,7 @@
         "meta": {},
         "attributes": {
           "TheHost": "0.0.0.0",
-          "ThePort": 80,
-          "_type": "Server",
-          "id": "MyServer"
+          "ThePort": 80
         }
       }
     }

--- a/pkg/input/golden_test/cfn/schemas-01.json
+++ b/pkg/input/golden_test/cfn/schemas-01.json
@@ -23,9 +23,7 @@
               "ToPort": 22
             }
           ],
-          "VpcId": "Vpc01",
-          "_type": "AWS::EC2::SecurityGroup",
-          "id": "SecurityGroup01"
+          "VpcId": "Vpc01"
         }
       }
     },
@@ -43,9 +41,7 @@
               "Key": "Group",
               "Value": "5"
             }
-          ],
-          "_type": "AWS::EC2::VPC",
-          "id": "Vpc01"
+          ]
         }
       }
     }


### PR DESCRIPTION
The adapter is a leftover from converting things from Regula.  As I'm porting
the k8s loader, and ripping it out there, I'd also like to remove it from other
places (the sole remaining of which is the cfn loader).