### PR TITLE
fix: CLOUD-656 derive input_type for legacy iac rules

### DIFF
--- a/changes/unreleased/Fixed-20220816-163457.yaml
+++ b/changes/unreleased/Fixed-20220816-163457.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: CLOUD-656 derive input_type for legacy iac rules
+time: 2022-08-16T16:34:57.339312-04:00

--- a/pkg/policy/legacyiac.go
+++ b/pkg/policy/legacyiac.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/snyk/policy-engine/pkg/input"
@@ -16,6 +17,29 @@ import (
 
 type LegacyIaCPolicy struct {
 	*BasePolicy
+}
+
+func (p *LegacyIaCPolicy) inputType() *input.Type {
+	for _, ele := range strings.Split(p.pkg, ".") {
+		switch ele {
+		case "arm":
+			return input.Arm
+		case "cloudformation":
+			return input.CloudFormation
+		case "kubernetes":
+			return input.Kubernetes
+		case "terraform":
+			return input.Terraform
+		}
+	}
+	return p.BasePolicy.inputType
+}
+
+func (p *LegacyIaCPolicy) InputType() string {
+	return p.inputType().Name
+}
+func (p *LegacyIaCPolicy) InputTypeMatches(inputType string) bool {
+	return p.inputType().Matches(inputType)
 }
 
 func (p *LegacyIaCPolicy) Eval(

--- a/pkg/policy/legacyiac_test.go
+++ b/pkg/policy/legacyiac_test.go
@@ -1,0 +1,54 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/snyk/policy-engine/pkg/input"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLegacyIaCInputType(t *testing.T) {
+	for _, tc := range []struct {
+		pkg      string
+		expected *input.Type
+	}{
+		{
+			pkg:      "data.schemas.arm",
+			expected: input.Arm,
+		},
+		{
+			pkg:      "data.schemas.cloudformation",
+			expected: input.CloudFormation,
+		},
+		{
+			pkg:      "data.schemas.kubernetes",
+			expected: input.Kubernetes,
+		},
+		{
+			pkg:      "data.schemas.terraform",
+			expected: input.Terraform,
+		},
+		{
+			pkg:      "data.schemas.terraform.kubernetes",
+			expected: input.Terraform,
+		},
+		{
+			pkg:      "data.schemas.terraform.azure",
+			expected: input.Terraform,
+		},
+		{
+			pkg:      "data.rules",
+			expected: input.Any,
+		},
+	} {
+		t.Run(tc.pkg, func(t *testing.T) {
+			policy := LegacyIaCPolicy{
+				BasePolicy: &BasePolicy{
+					pkg:       tc.pkg,
+					inputType: input.Any,
+				},
+			}
+			assert.Equal(t, tc.expected, policy.inputType())
+		})
+	}
+}


### PR DESCRIPTION
Currently, legacy IaC policies are always interpreted to have the `input.Any` type, because they do not have an `input_type` rule as defined in our spec. This PR adds `LegacyIaCPolicy` implementations of `InputType()` and `InputTypeMatches()` that use the package name to determine the policy's input type.

The end result is that we will filter which legacy IaC rules we run based the package name.