### PR TITLE
Export all IaCConfiguration types [TFCSCM-166]

### DIFF
--- a/changes/unreleased/Changed-20220819-130126.yaml
+++ b/changes/unreleased/Changed-20220819-130126.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: export all `IaCConfiguration` types.
+time: 2022-08-19T13:01:26.391398717+02:00

--- a/pkg/input/arm.go
+++ b/pkg/input/arm.go
@@ -60,7 +60,7 @@ func (c *ArmDetector) DetectFile(i *File, opts DetectOptions) (IACConfiguration,
 	}
 
 	path := i.Path
-	return &armConfiguration{
+	return &ArmConfiguration{
 		path:       path,
 		template:   template,
 		discovered: discovered,
@@ -72,14 +72,14 @@ func (c *ArmDetector) DetectDirectory(i *Directory, opts DetectOptions) (IACConf
 	return nil, nil
 }
 
-type armConfiguration struct {
+type ArmConfiguration struct {
 	path       string
 	template   *arm_Template
 	discovered map[string]arm_DiscoverResource
 	source     *SourceInfoNode
 }
 
-func (l *armConfiguration) ToState() models.State {
+func (l *ArmConfiguration) ToState() models.State {
 	// Set of all existing resources for the resolver.
 	resourceSet := map[string]struct{}{}
 	for id := range l.discovered {
@@ -107,7 +107,7 @@ func (l *armConfiguration) ToState() models.State {
 	}
 }
 
-func (l *armConfiguration) Location(path []interface{}) (LocationStack, error) {
+func (l *ArmConfiguration) Location(path []interface{}) (LocationStack, error) {
 	// Format is {resourceNamespace, resourceType, resourceId, attributePath...}
 	if l.source == nil || len(path) < 3 {
 		return nil, nil
@@ -139,11 +139,11 @@ func (l *armConfiguration) Location(path []interface{}) (LocationStack, error) {
 	return []Location{{Path: l.path, Line: line, Col: column}}, err
 }
 
-func (l *armConfiguration) LoadedFiles() []string {
+func (l *ArmConfiguration) LoadedFiles() []string {
 	return []string{l.path}
 }
 
-func (l *armConfiguration) Errors() []error {
+func (l *ArmConfiguration) Errors() []error {
 	return []error{}
 }
 

--- a/pkg/input/cfn.go
+++ b/pkg/input/cfn.go
@@ -58,7 +58,7 @@ func (c *CfnDetector) DetectFile(i *File, opts DetectOptions) (IACConfiguration,
 		source = nil // Don't consider source code locations essential.
 	}
 
-	return &cfnConfiguration{
+	return &CfnConfiguration{
 		path:      path,
 		template:  *template,
 		source:    source,
@@ -133,14 +133,14 @@ func (tmpl *cfnTemplate) resources() map[string]models.ResourceState {
 	return resources
 }
 
-type cfnConfiguration struct {
+type CfnConfiguration struct {
 	path      string
 	template  cfnTemplate
 	source    *SourceInfoNode
 	resources map[string]models.ResourceState
 }
 
-func (l *cfnConfiguration) ToState() models.State {
+func (l *CfnConfiguration) ToState() models.State {
 	resources := []models.ResourceState{}
 	for _, resource := range l.resources {
 		resource.Namespace = l.path
@@ -160,7 +160,7 @@ func (l *cfnConfiguration) ToState() models.State {
 	}
 }
 
-func (l *cfnConfiguration) Location(path []interface{}) (LocationStack, error) {
+func (l *CfnConfiguration) Location(path []interface{}) (LocationStack, error) {
 	// Format is {resourceNamespace, resourceType, resourceId, attributePath...}
 	if l.source == nil || len(path) < 3 {
 		return nil, nil
@@ -185,11 +185,11 @@ func (l *cfnConfiguration) Location(path []interface{}) (LocationStack, error) {
 	return []Location{{Path: l.path, Line: line, Col: column}}, err
 }
 
-func (l *cfnConfiguration) LoadedFiles() []string {
+func (l *CfnConfiguration) LoadedFiles() []string {
 	return []string{l.path}
 }
 
-func (l *cfnConfiguration) Errors() []error {
+func (l *CfnConfiguration) Errors() []error {
 	return []error{}
 }
 

--- a/pkg/input/k8s.go
+++ b/pkg/input/k8s.go
@@ -72,7 +72,7 @@ func (c *KubernetesDetector) DetectFile(i *File, opts DetectOptions) (IACConfigu
 		}
 	}
 
-	return &k8s_Configuration{
+	return &K8s_Configuration{
 		path:      i.Path,
 		resources: resources,
 		sources:   sources,
@@ -83,13 +83,13 @@ func (c *KubernetesDetector) DetectDirectory(i *Directory, opts DetectOptions) (
 	return nil, nil
 }
 
-type k8s_Configuration struct {
+type K8s_Configuration struct {
 	path      string
 	resources map[k8s_Key]models.ResourceState
 	sources   map[k8s_Key]SourceInfoNode
 }
 
-func (l *k8s_Configuration) ToState() models.State {
+func (l *K8s_Configuration) ToState() models.State {
 	resourcesByType := map[string]map[string]models.ResourceState{}
 	for _, resource := range l.resources {
 		if _, ok := resourcesByType[resource.ResourceType]; !ok {
@@ -113,7 +113,7 @@ func (l *k8s_Configuration) ToState() models.State {
 	}
 }
 
-func (l *k8s_Configuration) Location(path []interface{}) (LocationStack, error) {
+func (l *K8s_Configuration) Location(path []interface{}) (LocationStack, error) {
 	// Format is {resourceNamespace, resourceType, resourceId, attributePath...}
 	if l.sources == nil || len(path) < 3 {
 		return nil, nil
@@ -156,11 +156,11 @@ func (l *k8s_Configuration) Location(path []interface{}) (LocationStack, error) 
 	}
 }
 
-func (l *k8s_Configuration) LoadedFiles() []string {
+func (l *K8s_Configuration) LoadedFiles() []string {
 	return []string{l.path}
 }
 
-func (l *k8s_Configuration) Errors() []error {
+func (l *K8s_Configuration) Errors() []error {
 	return []error{}
 }
 

--- a/pkg/input/tfplan.go
+++ b/pkg/input/tfplan.go
@@ -45,7 +45,7 @@ func (t *TfPlanDetector) DetectFile(i *File, opts DetectOptions) (IACConfigurati
 		return nil, fmt.Errorf("%w", InvalidInput)
 	}
 
-	return &tfPlan{
+	return &TfPlan{
 		path: i.Path,
 		plan: rawPlan,
 	}, nil
@@ -55,20 +55,20 @@ func (t *TfPlanDetector) DetectDirectory(i *Directory, opts DetectOptions) (IACC
 	return nil, nil
 }
 
-type tfPlan struct {
+type TfPlan struct {
 	path string
 	plan *tfplan_Plan
 }
 
-func (l *tfPlan) LoadedFiles() []string {
+func (l *TfPlan) LoadedFiles() []string {
 	return []string{l.path}
 }
 
-func (l *tfPlan) Location(_ []interface{}) (LocationStack, error) {
+func (l *TfPlan) Location(_ []interface{}) (LocationStack, error) {
 	return []Location{{Path: l.path}}, nil
 }
 
-func (l *tfPlan) ToState() models.State {
+func (l *TfPlan) ToState() models.State {
 	return models.State{
 		InputType:           TerraformPlan.Name,
 		EnvironmentProvider: "iac",
@@ -82,7 +82,7 @@ func (l *tfPlan) ToState() models.State {
 	}
 }
 
-func (l *tfPlan) Errors() []error {
+func (l *TfPlan) Errors() []error {
 	return []error{}
 }
 

--- a/pkg/input/tfstate.go
+++ b/pkg/input/tfstate.go
@@ -43,7 +43,7 @@ func (t *TfStateDetector) DetectFile(i *File, opts DetectOptions) (IACConfigurat
 		return nil, fmt.Errorf("%w", InvalidInput)
 	}
 
-	return &tfstateLoader{
+	return &TfstateLoader{
 		path:  i.Path,
 		state: tfstate,
 	}, nil
@@ -53,7 +53,7 @@ func (t *TfStateDetector) DetectDirectory(i *Directory, opts DetectOptions) (IAC
 	return nil, nil
 }
 
-type tfstateLoader struct {
+type TfstateLoader struct {
 	path  string
 	state tfstate_State
 }
@@ -76,19 +76,19 @@ type tfstate_ResourceInstance struct {
 	Attributes map[string]interface{} `yaml:"attributes"`
 }
 
-func (l *tfstateLoader) LoadedFiles() []string {
+func (l *TfstateLoader) LoadedFiles() []string {
 	return []string{l.path}
 }
 
-func (l *tfstateLoader) Errors() []error {
+func (l *TfstateLoader) Errors() []error {
 	return []error{}
 }
 
-func (l *tfstateLoader) Location(attributePath []interface{}) (LocationStack, error) {
+func (l *TfstateLoader) Location(attributePath []interface{}) (LocationStack, error) {
 	return nil, nil
 }
 
-func (l *tfstateLoader) ToState() models.State {
+func (l *TfstateLoader) ToState() models.State {
 	resources := []models.ResourceState{}
 	environmentProvider := ""
 


### PR DESCRIPTION
Pardon the unsolicited PR without discussing this first, the changes should be minimal enough.

I've been working on optionally using the new policy-engine for cloud-config-policy-engine's `/detect` endpoint, which is used in the SCM flow's discovery step. A rough summary of how that works:
1. Our IaC hooks tell registry's SCM orchestration to grab all files ending with common IaC file extensions (`.tf`, `.json`, `.yaml`, etc.)
2. Not all of those files will be IaC files, so in the discovery step of the SCM orchestration we're inspecting these files by sending them from registry to our cloud-config-policy-engine's `/detect` endpoint.
3. Only the ones we can detect will then be evaluated later on in the SCM orchestration.

We're using policy-engine's `input.MultiDetector` for JSON and YAML files, but then need to inspect the type of the result to accurately return a mime-type describing the detected file type.
So far only `input.HclConfiguration` was exported, all others weren't.

I've opted to export all of the types that are returned in the various detector's `DetectFile` results, however strictly speaking our cloud-config-policy-engine service currently only needs HCL, TF Plan, K8s, and CFN to be exported.