### PR TITLE
feat: TFCSCM-166 add Type() method to input.IACConfiguration

### DIFF
--- a/changes/unreleased/Added-20220819-113817.yaml
+++ b/changes/unreleased/Added-20220819-113817.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Type() method to input.IACConfiguration
+time: 2022-08-19T11:38:17.955504-04:00

--- a/changes/unreleased/Added-20220819-113838.yaml
+++ b/changes/unreleased/Added-20220819-113838.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Equal() method to input.Type
+time: 2022-08-19T11:38:38.90297-04:00

--- a/pkg/input/arm.go
+++ b/pkg/input/arm.go
@@ -147,6 +147,10 @@ func (l *armConfiguration) Errors() []error {
 	return []error{}
 }
 
+func (l *armConfiguration) Type() *Type {
+	return Arm
+}
+
 type arm_Template struct {
 	Schema         string         `json:"$schema"`
 	ContentVersion string         `json:"contentVersion"`

--- a/pkg/input/cfn.go
+++ b/pkg/input/cfn.go
@@ -193,6 +193,10 @@ func (l *cfnConfiguration) Errors() []error {
 	return []error{}
 }
 
+func (l *cfnConfiguration) Type() *Type {
+	return CloudFormation
+}
+
 func decodeMap(node *yaml.Node) (map[string]interface{}, error) {
 	if len(node.Content)%2 != 0 {
 		return nil, fmt.Errorf("Malformed map at line %v, col %v", node.Line, node.Column)

--- a/pkg/input/detector.go
+++ b/pkg/input/detector.go
@@ -36,6 +36,8 @@ type IACConfiguration interface {
 	// Some files may load but still have errors in them.  You can retrieve
 	// them here.
 	Errors() []error
+	// Type returns the *input.Type of this configuration
+	Type() *Type
 }
 
 // Location is a filepath, line and column.

--- a/pkg/input/k8s.go
+++ b/pkg/input/k8s.go
@@ -175,6 +175,10 @@ func (l *k8s_Configuration) Errors() []error {
 	return l.errors
 }
 
+func (l *k8s_Configuration) Type() *Type {
+	return Kubernetes
+}
+
 func splitYAML(data []byte) ([]map[string]interface{}, error) {
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	var documents []map[string]interface{}

--- a/pkg/input/streamlinedstate.go
+++ b/pkg/input/streamlinedstate.go
@@ -115,6 +115,10 @@ func (l *streamlinedStateLoader) Errors() []error {
 	return []error{}
 }
 
+func (l *streamlinedStateLoader) Type() *Type {
+	return StreamlinedState
+}
+
 func extractString(m map[string]interface{}, key string) string {
 	v, ok := m[key]
 	if !ok {

--- a/pkg/input/tf.go
+++ b/pkg/input/tf.go
@@ -140,3 +140,7 @@ func (c *HclConfiguration) Errors() []error {
 	errors = append(errors, c.evaluation.Errors()...)
 	return errors
 }
+
+func (l *HclConfiguration) Type() *Type {
+	return TerraformHCL
+}

--- a/pkg/input/tfplan.go
+++ b/pkg/input/tfplan.go
@@ -86,6 +86,10 @@ func (l *tfPlan) Errors() []error {
 	return []error{}
 }
 
+func (l *tfPlan) Type() *Type {
+	return TerraformPlan
+}
+
 // This (among with other types prefixed with tfplan_) matches the JSON
 // format exactly.
 type tfplan_Plan struct {

--- a/pkg/input/tfstate.go
+++ b/pkg/input/tfstate.go
@@ -84,6 +84,10 @@ func (l *tfstateLoader) Errors() []error {
 	return []error{}
 }
 
+func (l *tfstateLoader) Type() *Type {
+	return TerraformState
+}
+
 func (l *tfstateLoader) Location(attributePath []interface{}) (LocationStack, error) {
 	return nil, nil
 }

--- a/pkg/input/types.go
+++ b/pkg/input/types.go
@@ -31,8 +31,40 @@ func (t *Type) Matches(inputType string) bool {
 	return false
 }
 
+// Returns true if this Type instance is exactly equal to other
+func (t *Type) Equals(other *Type) bool {
+	if t == other {
+		return true
+	}
+	if !(t.Name == other.Name) {
+		return false
+	}
+	if !(len(t.Aliases) == len(other.Aliases)) {
+		return false
+	}
+	for idx, a := range t.Aliases {
+		if a != other.Aliases[idx] {
+			return false
+		}
+	}
+	return t.Children.Equals(other.Children)
+}
+
 // Types is a slice of Type struct.
 type Types []*Type
+
+// Returns true if this Types instance is exactly equal to other
+func (t Types) Equals(other Types) bool {
+	if len(t) != len(other) {
+		return false
+	}
+	for idx, a := range t {
+		if !a.Equals(other[idx]) {
+			return false
+		}
+	}
+	return true
+}
 
 // FromString returns the first InputType where either its name or aliases match the
 // given input type string. This method is case-insensitive.

--- a/pkg/input/types_test.go
+++ b/pkg/input/types_test.go
@@ -1,0 +1,96 @@
+package input_test
+
+import (
+	"testing"
+
+	"github.com/snyk/policy-engine/pkg/input"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTypeEqual(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		a        *input.Type
+		b        *input.Type
+		expected bool
+	}{
+		{
+			name:     "pointer equal",
+			a:        input.Terraform,
+			b:        input.Terraform,
+			expected: true,
+		},
+		{
+			name:     "simple equal",
+			a:        &input.Type{Name: "foo"},
+			b:        &input.Type{Name: "foo"},
+			expected: true,
+		},
+		{
+			name: "equal with aliases",
+			a: &input.Type{
+				Name:    "foo",
+				Aliases: []string{"f", "bar"},
+			},
+			b: &input.Type{
+				Name:    "foo",
+				Aliases: []string{"f", "bar"},
+			},
+			expected: true,
+		},
+		{
+			name: "equal with children",
+			a: &input.Type{
+				Name: "foo",
+				Children: input.Types{
+					&input.Type{Name: "bar"},
+				},
+			},
+			b: &input.Type{
+				Name: "foo",
+				Children: input.Types{
+					&input.Type{Name: "bar"},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:     "simple non-equal",
+			a:        &input.Type{Name: "foo"},
+			b:        &input.Type{Name: "bar"},
+			expected: false,
+		},
+		{
+			name: "non-equal from aliases",
+			a: &input.Type{
+				Name:    "foo",
+				Aliases: []string{"f", "bar"},
+			},
+			b: &input.Type{
+				Name:    "foo",
+				Aliases: []string{"f", "baz"},
+			},
+			expected: false,
+		},
+		{
+			name: "non-equal from children",
+			a: &input.Type{
+				Name: "foo",
+				Children: input.Types{
+					&input.Type{Name: "bar"},
+				},
+			},
+			b: &input.Type{
+				Name: "foo",
+				Children: input.Types{
+					&input.Type{Name: "baz"},
+				},
+			},
+			expected: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, tc.a.Equals(tc.b))
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a `Type()` method to the `input.IACConfiguration` interface to enable library users to get the input type from a loaded configuration. I've also added an `Equal()` method to `input.Type` so that types can be compared.