### PR TITLE
[CLOUD-731] Convert legacy iac k8s messages to OPA style paths

### DIFF
--- a/changes/unreleased/Changed-20220830-181009.yaml
+++ b/changes/unreleased/Changed-20220830-181009.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Convert legacy iac k8s messages to OPA style paths
+time: 2022-08-30T18:10:09.164317458+02:00

--- a/pkg/policy/legacyiac/k8s_test.go
+++ b/pkg/policy/legacyiac/k8s_test.go
@@ -140,6 +140,14 @@ func TestK8sParseMsg(t *testing.T) {
 									"name":  "pause1",
 									"image": "k8s.gcr.io/pause",
 								},
+								map[string]interface{}{
+									"name":  "pause2",
+									"image": "k8s.gcr.io/pause",
+								},
+								map[string]interface{}{
+									"name":  "pause3",
+									"image": "k8s.gcr.io/pause",
+								},
 							},
 						},
 					},
@@ -176,6 +184,15 @@ func TestK8sParseMsg(t *testing.T) {
 				ResourceType:      "Pod",
 				ResourceNamespace: "default",
 				Path:              []interface{}{"spec", "containers", 0},
+			},
+		},
+		{
+			msg: "pod.spec.containers[pause2].image",
+			expected: legacyiac.ParsedMsg{
+				ResourceID:        "invalid1",
+				ResourceType:      "Pod",
+				ResourceNamespace: "default",
+				Path:              []interface{}{"spec", "containers", 1, "image"},
 			},
 		},
 	} {


### PR DESCRIPTION
The snyk legacy rules produce messages that sometimes refer to attributes (e.g.
name) rather than indices.  This is different from the stricter OPA paths we
use in Policy Engine (ints for array indices and strings for object keys).  An
example of a k8s manifest where this applies is:

    # https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
    apiVersion: v1
    kind: Pod
    metadata:
      name: security-context-demo-4
    spec:
      containers:
      - name: sec-ctx-4
        image: gcr.io/google-samples/node-hello:1.0
        securityContext:
          capabilities:
            add: ["NET_ADMIN", "SYS_TIME"]

The legacy IaC rules will produce a path like:

    spec.containers[sec-snyk-ctx4].image

What we want to store going forward is the standardized:

    spec.containers[0].image