### PR TITLE
feat: CLOUD-727 method to extract all policy metadata

### DIFF
--- a/changes/unreleased/Added-20220902-112333.yaml
+++ b/changes/unreleased/Added-20220902-112333.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: method to extract all policy metadata
+time: 2022-09-02T11:23:33.272641-04:00

--- a/cmd/metadata.go
+++ b/cmd/metadata.go
@@ -1,0 +1,65 @@
+// Copyright 2022 Snyk Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/snyk/policy-engine/pkg/data"
+	"github.com/snyk/policy-engine/pkg/engine"
+	"github.com/snyk/policy-engine/pkg/snapshot_testing"
+	"github.com/spf13/cobra"
+)
+
+var metadataCmd = &cobra.Command{
+	Use:   "metadata [-d <rules/metadata>...]",
+	Short: "Return metadata from the given rules",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := cmdLogger()
+		snapshot_testing.GlobalRegisterNoop()
+		providers := []data.Provider{
+			data.PureRegoLibProvider(),
+		}
+		for _, path := range rootCmdRegoPaths {
+			if isTgz(path) {
+				f, err := os.Open(path)
+				if err != nil {
+					return err
+				}
+				providers = append(providers, data.TarGzProvider(f))
+			} else {
+				providers = append(providers, data.LocalProvider(path))
+			}
+		}
+		ctx := context.Background()
+		eng, err := engine.NewEngine(ctx, &engine.EngineOptions{
+			Providers: providers,
+			Logger:    logger,
+		})
+		if err != nil {
+			return err
+		}
+		metadata := eng.Metadata(ctx)
+		bytes, err := json.MarshalIndent(metadata, "  ", "  ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stdout, "%s\n", string(bytes))
+		return nil
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -97,4 +97,5 @@ func init() {
 	rootCmd.AddCommand(fixtureCmd)
 	rootCmd.AddCommand(replCmd)
 	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(metadataCmd)
 }


### PR DESCRIPTION
This PR adds an `Engine.Metadata` method which returns the metadata of all of its polices.