### PR TITLE
[CTX-403] feat: move ResourcesResolver injection to eval time

### DIFF
--- a/changes/unreleased/Changed-20220906-144018.yaml
+++ b/changes/unreleased/Changed-20220906-144018.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'BREAKING: move ResourcesResolver chain to eval time'
+time: 2022-09-06T14:40:18.964826+01:00

--- a/docs/library_usage.md
+++ b/docs/library_usage.md
@@ -287,10 +287,13 @@ func getCloudResources(ctx context.Context, query policy.ResourcesQuery) (policy
 
 ```
 
-Then, they can inject that into the engine's resolver chain:
+Then, they can inject that into the engine's resolver chain at evaluation time:
 
 ```go
   engine, err := upe.NewEngine(ctx, &upe.EngineOptions{
+    ...
+  })
+  results := engine.Eval(ctx, &engine.EvalOptions{
     ...
     ResourcesResolver: policy.ResourcesResolver(getCloudResources),
   })


### PR DESCRIPTION
BREAKING CHANGE: ResourcesResolvers were previously injected into
EngineOptions, but weren't used until Eval(), at which time they were
transposed to EvalOptions. This starts to matter when we need to run
Eval() more than once but with different ResourcesResolver chains, in
order to compare results, and want to avoid duplicating the work done at
NewEngine() time.

---

Needed for https://snyksec.atlassian.net/browse/CTX-403, but only tenuously related to that.

As far as we know, cloud context scans are the only current use case of ResourcesResolvers, and we're happy to consume our own breaking change. We could write this in a non-breaking way, by adding a duplicate field to EvalOptions and having it supersede EngineOptions, but this feels unnecessary.

Paired with @moadibfr 