### PR TITLE
feat: CLOUD-795 rego API support for secondary resource deny

### DIFF
--- a/changes/unreleased/Added-20220907-154554.yaml
+++ b/changes/unreleased/Added-20220907-154554.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Rego API support for secondary resource denies
+time: 2022-09-07T15:45:54.36275-04:00

--- a/docs/proposals.md
+++ b/docs/proposals.md
@@ -1,0 +1,9 @@
+# Design proposals
+
+This document tracks the accepted design proposals and their implementation
+status.
+
+| Title                                                                 | File                                                                             | Implemented? | Comments                                                                                                        |
+| :-------------------------------------------------------------------- | :------------------------------------------------------------------------------- | :----------: | :-------------------------------------------------------------------------------------------------------------- |
+| Snapshot testing for policies                                         | [./design/policy-test-enhancement.md](./design/policy-test-enhancement.md)       |     Yes      |                                                                                                                 |
+| Enhanced mechanism to report secondary resources and their attributes | [./design/deny-secondary-enhancement.md](./design/deny-secondary-enhancement.md) |  Partially   | The Rego API has been modified to support this change. The output format changes have not been implemented yet. |

--- a/examples/09-secondary-resource-deny.rego
+++ b/examples/09-secondary-resource-deny.rego
@@ -1,0 +1,68 @@
+# Sometimes we want to write a policy that says:
+# "This primary resource is vulnerable, because of this secondary resource"
+# This example demonstrates that concept by using the primary_resource attribute
+# in its deny rule.
+package rules.snyk_009.tf
+
+import data.snyk
+
+buckets := snyk.resources("aws_s3_bucket")
+encryption_configs := snyk.resources("aws_s3_bucket_server_side_encryption_configuration")
+
+belongs_to_bucket(config, bucket) {
+  config.bucket == bucket.bucket
+}
+
+belongs_to_bucket(config, bucket) {
+  config.bucket == bucket.id
+}
+
+# Here we're building a map of bucket -> all of its encryption configuration
+# resources. Note that Rego lets you use an object as a key in another object.
+configs_by_bucket := {bucket: configs |
+  bucket := buckets[_]
+  configs := [config | 
+    config := encryption_configs[_]
+    belongs_to_bucket(config, bucket)
+  ]
+}
+
+# This function returns the paths to any SSE algorithm in this encryptiong
+# configuration that's not KMS.
+bad_attrs(config) = ret {
+  ret := [["rule", j, "apply_server_side_encryption_by_default", k] |
+    config.rule[j].apply_server_side_encryption_by_default[k].sse_algorithm != "aws:kms"
+  ]
+}
+
+# Here we're demonstrating a deny on a secondary resource. You can think of this
+# rule as saying:
+# "This bucket is invalid because of this config, and these attributes of the 
+# config explain why."
+deny[info] {
+  config := configs_by_bucket[bucket][_]
+  bad := bad_attrs(config)
+  count(bad) > 0
+  info := {
+    "primary_resource": bucket,
+    "resource": config,
+    # These are attributes from the encryption configuration (i.e. the secondary
+    # resource), and not the bucket.
+    "attributes": bad
+  }
+}
+
+# Our resources rule is written to return _all_ resources and attributes that
+# this policy inspected. The Policy Engine uses these results to know which
+# resources were note failed by this policy, as well as which attributes
+# factored into that decision.
+resources[info] {
+  config := configs_by_bucket[bucket][_]
+  info := {
+    "primary_resource": bucket,
+    "resource": config,
+    "attributes": [["rule", j, "apply_server_side_encryption_by_default", k] |
+      _ = config.rule[j].apply_server_side_encryption_by_default[k].sse_algorithm
+    ]
+  }
+}

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -38,6 +38,20 @@ resource "aws_s3_bucket" "bucket3" {
   }
 }
 
+resource "aws_s3_bucket" "aes_bucket" {
+  bucket = "i-use-aes-encryption"
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "aes_bucket" {
+  bucket = aws_s3_bucket.aes_bucket.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm     = "AES256"
+    }
+  }
+}
+
 resource "aws_cloudtrail" "cloudtrail1" {
   name                          = "cloudtrail1"
   s3_bucket_name                = aws_s3_bucket.bucket1.id

--- a/pkg/policy/base.go
+++ b/pkg/policy/base.go
@@ -426,13 +426,14 @@ type policyResultResource struct {
 
 // This struct represents the common return format for the policy engine policies.
 type policyResult struct {
-	Message      string                `json:"message"`
-	Resource     *policyResultResource `json:"resource"`
-	ResourceType string                `json:"resource_type"`
-	Remediation  string                `json:"remediation"`
-	Severity     string                `json:"severity"`
-	Attributes   [][]interface{}       `json:"attributes"`
-	Correlation  string                `json:"correlation"`
+	Message         string                `json:"message"`
+	Resource        *policyResultResource `json:"resource"`
+	PrimaryResource *policyResultResource `json:"primary_resource"`
+	ResourceType    string                `json:"resource_type"`
+	Remediation     string                `json:"remediation"`
+	Severity        string                `json:"severity"`
+	Attributes      [][]interface{}       `json:"attributes"`
+	Correlation     string                `json:"correlation"`
 
 	// Backwards compatibility
 	FugueValid             bool   `json:"valid"`
@@ -463,9 +464,21 @@ func RuleResultResourceKey(r models.RuleResultResource) ResourceKey {
 	}
 }
 
+func (result policyResult) GetResource() *policyResultResource {
+	if result.Resource != nil {
+		return result.Resource
+	} else if result.PrimaryResource != nil {
+		return result.PrimaryResource
+	} else {
+		return nil
+	}
+}
+
 func (result policyResult) GetCorrelation() string {
 	if result.Correlation != "" {
 		return result.Correlation
+	} else if result.PrimaryResource != nil {
+		return result.PrimaryResource.Correlation()
 	} else if result.Resource != nil {
 		return result.Resource.Correlation()
 	} else {

--- a/pkg/policy/multi.go
+++ b/pkg/policy/multi.go
@@ -145,10 +145,11 @@ func processMultiDenyPolicyResult(
 			builder.resourceType = result.ResourceType
 		}
 
-		if result.Resource != nil {
-			builder.addResource(result.Resource.Key())
+		if resource := result.GetResource(); resource != nil {
+			resourceKey := resource.Key()
+			builder.addResource(resourceKey)
 			for _, attr := range result.Attributes {
-				builder.addResourceAttribute(result.Resource.Key(), attr)
+				builder.addResourceAttribute(resourceKey, attr)
 			}
 		}
 		if result.Remediation != "" {


### PR DESCRIPTION
This PR adds support for the `primary_resource` attribute in `deny` rules. This implements the Rego API changes needed to enable "secondary resource denies" as described in https://github.com/snyk/policy-engine/pull/114

The rest of that proposal requires breaking changes to the output format, which will be addressed in separate PRs. I've added a small document with a table to track the status of that proposal as well as future proposals.