### PR TITLE
feat: add `product` metadata field

### DIFF
--- a/changes/unreleased/Added-20220918-162606.yaml
+++ b/changes/unreleased/Added-20220918-162606.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: new `product` metadata field
+time: 2022-09-18T16:26:06.723536+03:00

--- a/docs/policy_spec.md
+++ b/docs/policy_spec.md
@@ -145,6 +145,7 @@ to clarify the intent of each field.
 | `service_group` | string | The service group of the primary resource associated with this policy (e.g. "EBS", "EC2")                        |
 | `controls`      | object | A map of rule set ID to a map of versions to a list of control IDs                                               |
 | `severity`      | string | The severity of the issue identified by this policy                                                              |
+| `product`       | array  | An array of the products this policy supports                                                                    |
 
 Example with all fields populated:
 

--- a/pkg/policy/base.go
+++ b/pkg/policy/base.go
@@ -141,6 +141,7 @@ type Metadata struct {
 	ServiceGroup string                         `json:"service_group"`
 	Controls     map[string]map[string][]string `json:"controls"`
 	Severity     string                         `json:"severity"`
+	Product      []string                       `json:"product"`
 }
 
 func (m Metadata) RemediationFor(inputType string) string {


### PR DESCRIPTION
To support the work of [filtering policies by product tag in the new Settings Page](https://snyksec.atlassian.net/browse/CFG-2147) we need to add to the PE `Metadata` structure type the new `product` field that was recently added.

@jason-snyk / @jaspervdj-snyk if I understand the code correctly this is the only change needed to add support for a new metadata field, if this is not the case please let me know :)