### PR TITLE
fix: CLOUD-809 support missing resource in ruleResultBuilder

### DIFF
--- a/changes/unreleased/Fixed-20220921-160954.yaml
+++ b/changes/unreleased/Fixed-20220921-160954.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Primary resource interpretation for missing-resource policies
+time: 2022-09-21T16:09:54.169437-04:00

--- a/pkg/policy/base.go
+++ b/pkg/policy/base.go
@@ -382,13 +382,12 @@ func (p *BasePolicy) resources(
 		return r, err
 	}
 	for _, result := range results {
-		if result.Resource == nil && result.PrimaryResource == nil {
-			continue
-		}
-
 		correlation := result.GetCorrelation()
 		if _, ok := r[correlation]; !ok {
 			r[correlation] = newRuleResultBuilder()
+		}
+		if result.ResourceType != "" {
+			r[correlation].setMissingResourceType(result.ResourceType)
 		}
 		if result.Resource != nil {
 			r[correlation].addResource(result.Resource.Key())
@@ -448,6 +447,7 @@ type resourcesResult struct {
 	PrimaryResource *policyResultResource `json:"primary_resource"`
 	Attributes      [][]interface{}       `json:"attributes"`
 	Correlation     string                `json:"correlation"`
+	ResourceType    string                `json:"resource_type"`
 }
 
 // Helper for unique resource identifiers, meant to be used as key in a `map`.
@@ -478,6 +478,8 @@ func (result policyResult) GetResource() *policyResultResource {
 func (result policyResult) GetCorrelation() string {
 	if result.Correlation != "" {
 		return result.Correlation
+	} else if result.ResourceType != "" {
+		return result.ResourceType
 	} else if result.PrimaryResource != nil {
 		return result.PrimaryResource.Correlation()
 	} else if result.Resource != nil {
@@ -523,6 +525,8 @@ func (result resourcesResult) GetResource() *policyResultResource {
 func (result resourcesResult) GetCorrelation() string {
 	if result.Correlation != "" {
 		return result.Correlation
+	} else if result.ResourceType != "" {
+		return result.ResourceType
 	} else if result.PrimaryResource != nil {
 		return result.PrimaryResource.Correlation()
 	} else if result.Resource != nil {

--- a/pkg/policy/ruleresultbuilder.go
+++ b/pkg/policy/ruleresultbuilder.go
@@ -28,6 +28,7 @@ import (
 type ruleResultBuilder struct {
 	passed            bool
 	ignored           bool
+	isMissingResource bool
 	messages          []string
 	resourceId        string
 	resourceNamespace string
@@ -42,6 +43,12 @@ func newRuleResultBuilder() *ruleResultBuilder {
 	return &ruleResultBuilder{
 		resources: map[ResourceKey]*models.RuleResultResource{},
 	}
+}
+
+func (builder *ruleResultBuilder) setMissingResourceType(resourceType string) *ruleResultBuilder {
+	builder.resourceType = resourceType
+	builder.isMissingResource = true
+	return builder
 }
 
 func (builder *ruleResultBuilder) setPrimaryResource(key ResourceKey) *ruleResultBuilder {
@@ -109,7 +116,7 @@ func (builder *ruleResultBuilder) toRuleResult() models.RuleResult {
 	resourceId := builder.resourceId
 	resourceNamespace := builder.resourceNamespace
 	resourceType := builder.resourceType
-	if len(resources) == 1 {
+	if !builder.isMissingResource && len(resources) == 1 {
 		resource := resources[0]
 		resourceId = resource.Id
 		resourceNamespace = resource.Namespace


### PR DESCRIPTION
This PR contains a stopgap fix for missing-resource policies. The way that we were calculating the primary resource for rule results meant that it was not possible to report secondary resources from a missing-resource policy. We have a longer-term need to come up with an intuitive syntax for these rules. But, for now authors will be able to specify `resource_type` in `resources[info]` rules in order to make it easy to correlate passing and failing missing-resource policy results:

```open-policy-agent
resources[info] {
	contact := valid_contacts[_]
	info := {
		"resource_type": "aws_account_alternate_contact",
		"resource": contact,
		"attributes": [["alternate_contact_type"]],
	}
}
```