### PR TITLE
fix: resource .id in repl/test

### DIFF
--- a/changes/unreleased/Fixed-20220927-154157.yaml
+++ b/changes/unreleased/Fixed-20220927-154157.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: resource .id in repl/test
+time: 2022-09-27T15:41:57.891580049+02:00

--- a/rego/snyk.rego
+++ b/rego/snyk.rego
@@ -18,13 +18,13 @@ resources(resource_type) = ret {
 	ret := [obj |
 		resource := input.resources[resource_type][_]
 		obj := object.union(
+			resource.attributes,
 			{
 				"id": resource.id,
 				"_type": resource_type,
 				"_namespace": resource.namespace,
 				"_meta": object.get(resource, "meta", {}),
 			},
-			resource.attributes,
 		)
 	]
 }

--- a/rego/snyk_test.rego
+++ b/rego/snyk_test.rego
@@ -1,0 +1,29 @@
+# Copyright 2022 Snyk Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package snyk_test
+
+import data.snyk
+
+test_resource_id {
+	# Test that we override any "id" set in the attributes, which is how the
+	# Go code behaves.
+	mock_input := {"resources": {"aws_s3_bucket": {"aws_s3_bucket.foo": {
+		"id": "aws_s3_bucket.foo",
+		"namespace": "test.plan",
+		"attributes": {"id": "bar"},
+	}}}}
+	buckets = snyk.resources("aws_s3_bucket") with input as mock_input
+	buckets[_].id == "aws_s3_bucket.foo"
+}


### PR DESCRIPTION
The pure rego implementation leaves .id as-is when it is already set in the attributes.  This differs from the Go implementation in `resourceStateToRegoInput` which is problematic.