### PR TITLE
feat: add support for .tf.json files

### DIFF
--- a/changes/unreleased/Added-20220927-133054.yaml
+++ b/changes/unreleased/Added-20220927-133054.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: support for .tf.json Terraform source code files
+time: 2022-09-27T13:30:54.117022-04:00

--- a/pkg/input/golden_test/tf/cdktf.out.json
+++ b/pkg/input/golden_test/tf/cdktf.out.json
@@ -1,0 +1,341 @@
+{
+  "format": "",
+  "format_version": "",
+  "input_type": "tf_hcl",
+  "environment_provider": "iac",
+  "meta": {
+    "filepath": "golden_test/tf/cdktf.out"
+  },
+  "resources": {
+    "aws_apigatewayv2_api": {
+      "aws_apigatewayv2_api.posts_api_api-gw_B6634897": {
+        "id": "aws_apigatewayv2_api.posts_api_api-gw_B6634897",
+        "resource_type": "aws_apigatewayv2_api",
+        "namespace": "golden_test/tf/cdktf.out",
+        "meta": {
+          "region": "eu-central-1",
+          "terraform": {
+            "provider_config": {
+              "region": "eu-central-1"
+            },
+            "provider_version_constraint": "4.27.0"
+          }
+        },
+        "attributes": {
+          "cors_configuration": {
+            "allow_headers": [
+              "content-type"
+            ],
+            "allow_methods": [
+              "*"
+            ],
+            "allow_origins": [
+              "*"
+            ]
+          },
+          "name": "sls-example-posts-development",
+          "protocol_type": "HTTP",
+          "target": "aws_lambda_function.posts_api_7D5242CA"
+        }
+      }
+    },
+    "aws_cloudfront_distribution": {
+      "aws_cloudfront_distribution.frontend_cf_6C82FC12": {
+        "id": "aws_cloudfront_distribution.frontend_cf_6C82FC12",
+        "resource_type": "aws_cloudfront_distribution",
+        "namespace": "golden_test/tf/cdktf.out",
+        "meta": {
+          "region": "eu-central-1",
+          "terraform": {
+            "provider_config": {
+              "region": "eu-central-1"
+            },
+            "provider_version_constraint": "4.27.0"
+          }
+        },
+        "attributes": {
+          "comment": "Serverless example frontend for env=development",
+          "default_cache_behavior": {
+            "allowed_methods": [
+              "DELETE",
+              "GET",
+              "HEAD",
+              "OPTIONS",
+              "PATCH",
+              "POST",
+              "PUT"
+            ],
+            "cached_methods": [
+              "GET",
+              "HEAD"
+            ],
+            "forwarded_values": {
+              "cookies": {
+                "forward": "none"
+              },
+              "query_string": false
+            },
+            "target_origin_id": "s3Origin",
+            "viewer_protocol_policy": "redirect-to-https"
+          },
+          "default_root_object": "index.html",
+          "enabled": true,
+          "origin": [
+            {
+              "custom_origin_config": {
+                "http_port": 80,
+                "https_port": 443,
+                "origin_protocol_policy": "http-only",
+                "origin_ssl_protocols": [
+                  "TLSv1.2",
+                  "TLSv1.1",
+                  "TLSv1"
+                ]
+              },
+              "domain_name": "aws_s3_bucket_website_configuration.frontend_website-configuration_53A72F76",
+              "origin_id": "s3Origin"
+            }
+          ],
+          "restrictions": {
+            "geo_restriction": {
+              "restriction_type": "none"
+            }
+          },
+          "viewer_certificate": {
+            "cloudfront_default_certificate": true
+          }
+        }
+      }
+    },
+    "aws_dynamodb_table": {
+      "aws_dynamodb_table.posts_storage_table_50F8EECB": {
+        "id": "aws_dynamodb_table.posts_storage_table_50F8EECB",
+        "resource_type": "aws_dynamodb_table",
+        "namespace": "golden_test/tf/cdktf.out",
+        "meta": {
+          "region": "eu-central-1",
+          "terraform": {
+            "provider_config": {
+              "region": "eu-central-1"
+            },
+            "provider_version_constraint": "4.27.0"
+          }
+        },
+        "attributes": {
+          "attribute": [
+            {
+              "name": "id",
+              "type": "S"
+            },
+            {
+              "name": "postedAt",
+              "type": "S"
+            }
+          ],
+          "billing_mode": "PAY_PER_REQUEST",
+          "hash_key": "id",
+          "name": "sls-posts-development",
+          "range_key": "postedAt"
+        }
+      }
+    },
+    "aws_iam_role": {
+      "aws_iam_role.posts_api_lambda-exec_B42627E0": {
+        "id": "aws_iam_role.posts_api_lambda-exec_B42627E0",
+        "resource_type": "aws_iam_role",
+        "namespace": "golden_test/tf/cdktf.out",
+        "meta": {
+          "region": "eu-central-1",
+          "terraform": {
+            "provider_config": {
+              "region": "eu-central-1"
+            },
+            "provider_version_constraint": "4.27.0"
+          }
+        },
+        "attributes": {
+          "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\",\"Sid\":\"\"}]}",
+          "inline_policy": [
+            {
+              "name": "AllowDynamoDB",
+              "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"dynamodb:Scan\",\"dynamodb:Query\",\"dynamodb:BatchGetItem\",\"dynamodb:GetItem\",\"dynamodb:PutItem\"],\"Resource\":\"aws_dynamodb_table.posts_storage_table_50F8EECB\",\"Effect\":\"Allow\"}]}"
+            }
+          ],
+          "name": "sls-example-post-api-lambda-exec-development"
+        }
+      }
+    },
+    "aws_iam_role_policy_attachment": {
+      "aws_iam_role_policy_attachment.posts_api_lambda-managed-policy_460C9C52": {
+        "id": "aws_iam_role_policy_attachment.posts_api_lambda-managed-policy_460C9C52",
+        "resource_type": "aws_iam_role_policy_attachment",
+        "namespace": "golden_test/tf/cdktf.out",
+        "meta": {
+          "region": "eu-central-1",
+          "terraform": {
+            "provider_config": {
+              "region": "eu-central-1"
+            },
+            "provider_version_constraint": "4.27.0"
+          }
+        },
+        "attributes": {
+          "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "role": "sls-example-post-api-lambda-exec-development"
+        }
+      }
+    },
+    "aws_lambda_function": {
+      "aws_lambda_function.posts_api_7D5242CA": {
+        "id": "aws_lambda_function.posts_api_7D5242CA",
+        "resource_type": "aws_lambda_function",
+        "namespace": "golden_test/tf/cdktf.out",
+        "meta": {
+          "region": "eu-central-1",
+          "terraform": {
+            "provider_config": {
+              "region": "eu-central-1"
+            },
+            "provider_version_constraint": "4.27.0"
+          }
+        },
+        "attributes": {
+          "environment": {
+            "variables": {
+              "DYNAMODB_TABLE_NAME": "sls-posts-development"
+            }
+          },
+          "filename": "assets/posts_api_code_lambda-asset_7F9E9FED/5C0604B46739D015AEDB1BA83362F19D/archive.zip",
+          "function_name": "sls-example-posts-api-development",
+          "handler": "index.handler",
+          "role": "aws_iam_role.posts_api_lambda-exec_B42627E0",
+          "runtime": "nodejs14.x",
+          "source_code_hash": "5C0604B46739D015AEDB1BA83362F19D"
+        }
+      }
+    },
+    "aws_lambda_permission": {
+      "aws_lambda_permission.posts_api_apigw-lambda_02C673B9": {
+        "id": "aws_lambda_permission.posts_api_apigw-lambda_02C673B9",
+        "resource_type": "aws_lambda_permission",
+        "namespace": "golden_test/tf/cdktf.out",
+        "meta": {
+          "region": "eu-central-1",
+          "terraform": {
+            "provider_config": {
+              "region": "eu-central-1"
+            },
+            "provider_version_constraint": "4.27.0"
+          }
+        },
+        "attributes": {
+          "action": "lambda:InvokeFunction",
+          "function_name": "sls-example-posts-api-development",
+          "principal": "apigateway.amazonaws.com",
+          "source_arn": "aws_apigatewayv2_api.posts_api_api-gw_B6634897/*/*"
+        }
+      }
+    },
+    "aws_s3_bucket": {
+      "aws_s3_bucket.frontend_bucket_EFDC2F3F": {
+        "id": "aws_s3_bucket.frontend_bucket_EFDC2F3F",
+        "resource_type": "aws_s3_bucket",
+        "namespace": "golden_test/tf/cdktf.out",
+        "meta": {
+          "region": "eu-central-1",
+          "terraform": {
+            "provider_config": {
+              "region": "eu-central-1"
+            },
+            "provider_version_constraint": "4.27.0"
+          }
+        },
+        "attributes": {
+          "bucket_prefix": "sls-example-frontend-development",
+          "tags": {
+            "hc-internet-facing": "true"
+          }
+        }
+      }
+    },
+    "aws_s3_bucket_policy": {
+      "aws_s3_bucket_policy.frontend_s3_policy_42C30805": {
+        "id": "aws_s3_bucket_policy.frontend_s3_policy_42C30805",
+        "resource_type": "aws_s3_bucket_policy",
+        "namespace": "golden_test/tf/cdktf.out",
+        "meta": {
+          "region": "eu-central-1",
+          "terraform": {
+            "provider_config": {
+              "region": "eu-central-1"
+            },
+            "provider_version_constraint": "4.27.0"
+          }
+        },
+        "attributes": {
+          "bucket": "aws_s3_bucket.frontend_bucket_EFDC2F3F",
+          "policy": "{\"Version\":\"2012-10-17\",\"Id\":\"PolicyForWebsiteEndpointsPublicContent\",\"Statement\":[{\"Sid\":\"PublicRead\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":[\"s3:GetObject\"],\"Resource\":[\"aws_s3_bucket.frontend_bucket_EFDC2F3F/*\",\"aws_s3_bucket.frontend_bucket_EFDC2F3F\"]}]}"
+        }
+      }
+    },
+    "aws_s3_bucket_website_configuration": {
+      "aws_s3_bucket_website_configuration.frontend_website-configuration_53A72F76": {
+        "id": "aws_s3_bucket_website_configuration.frontend_website-configuration_53A72F76",
+        "resource_type": "aws_s3_bucket_website_configuration",
+        "namespace": "golden_test/tf/cdktf.out",
+        "meta": {
+          "region": "eu-central-1",
+          "terraform": {
+            "provider_config": {
+              "region": "eu-central-1"
+            },
+            "provider_version_constraint": "4.27.0"
+          }
+        },
+        "attributes": {
+          "bucket": "aws_s3_bucket.frontend_bucket_EFDC2F3F",
+          "error_document": {
+            "key": "index.html"
+          },
+          "index_document": {
+            "suffix": "index.html"
+          }
+        }
+      }
+    },
+    "data.terraform_remote_state": {
+      "data.terraform_remote_state.cross-stack-reference-input-posts-dev": {
+        "id": "data.terraform_remote_state.cross-stack-reference-input-posts-dev",
+        "resource_type": "data.terraform_remote_state",
+        "namespace": "golden_test/tf/cdktf.out",
+        "meta": {},
+        "attributes": {
+          "backend": "local",
+          "config": {
+            "path": "cdktf-integration-serverless-example/terraform.posts-dev.tfstate"
+          },
+          "workspace": "default"
+        }
+      }
+    },
+    "local_file": {
+      "local_file.frontend_env_FADFC9DB": {
+        "id": "local_file.frontend_env_FADFC9DB",
+        "resource_type": "local_file",
+        "namespace": "golden_test/tf/cdktf.out",
+        "meta": {
+          "terraform": {
+            "provider_version_constraint": "2.2.3"
+          }
+        },
+        "attributes": {
+          "content": "S3_BUCKET_FRONTEND=aws_s3_bucket.frontend_bucket_EFDC2F3F\nREACT_APP_API_ENDPOINT=data.terraform_remote_state.cross-stack-reference-input-posts-dev",
+          "filename": "cdktf-integration-serverless-example/frontend/code/.env.production.local"
+        }
+      }
+    }
+  },
+  "scope": {
+    "filepath": "golden_test/tf/cdktf.out"
+  }
+}

--- a/pkg/input/golden_test/tf/cdktf.out/frontend-dev.tf.json
+++ b/pkg/input/golden_test/tf/cdktf.out/frontend-dev.tf.json
@@ -1,0 +1,182 @@
+{
+  "//": {
+    "metadata": {
+      "backend": "local",
+      "overrides": {
+        "output": [
+          "value"
+        ]
+      },
+      "stackName": "frontend-dev",
+      "version": "0.12.1"
+    },
+    "outputs": {
+      "frontend-dev": {
+        "frontend": {
+          "frontend_domainname": "frontend_frontend_domainname_0AC0A4F3"
+        }
+      }
+    }
+  },
+  "data": {
+    "terraform_remote_state": {
+      "cross-stack-reference-input-posts-dev": {
+        "backend": "local",
+        "config": {
+          "path": "cdktf-integration-serverless-example/terraform.posts-dev.tfstate"
+        },
+        "workspace": "${terraform.workspace}"
+      }
+    }
+  },
+  "output": {
+    "frontend_frontend_domainname_0AC0A4F3": {
+      "value": "https://${aws_cloudfront_distribution.frontend_cf_6C82FC12.domain_name}"
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "region": "eu-central-1"
+      }
+    ],
+    "local": [
+      {
+      }
+    ]
+  },
+  "resource": {
+    "aws_cloudfront_distribution": {
+      "frontend_cf_6C82FC12": {
+        "//": {
+          "metadata": {
+            "path": "frontend-dev/frontend/cf",
+            "uniqueId": "frontend_cf_6C82FC12"
+          }
+        },
+        "comment": "Serverless example frontend for env=development",
+        "default_cache_behavior": {
+          "allowed_methods": [
+            "DELETE",
+            "GET",
+            "HEAD",
+            "OPTIONS",
+            "PATCH",
+            "POST",
+            "PUT"
+          ],
+          "cached_methods": [
+            "GET",
+            "HEAD"
+          ],
+          "forwarded_values": {
+            "cookies": {
+              "forward": "none"
+            },
+            "query_string": false
+          },
+          "target_origin_id": "s3Origin",
+          "viewer_protocol_policy": "redirect-to-https"
+        },
+        "default_root_object": "index.html",
+        "enabled": true,
+        "origin": [
+          {
+            "custom_origin_config": {
+              "http_port": 80,
+              "https_port": 443,
+              "origin_protocol_policy": "http-only",
+              "origin_ssl_protocols": [
+                "TLSv1.2",
+                "TLSv1.1",
+                "TLSv1"
+              ]
+            },
+            "domain_name": "${aws_s3_bucket_website_configuration.frontend_website-configuration_53A72F76.website_endpoint}",
+            "origin_id": "s3Origin"
+          }
+        ],
+        "restrictions": {
+          "geo_restriction": {
+            "restriction_type": "none"
+          }
+        },
+        "viewer_certificate": {
+          "cloudfront_default_certificate": true
+        }
+      }
+    },
+    "aws_s3_bucket": {
+      "frontend_bucket_EFDC2F3F": {
+        "//": {
+          "metadata": {
+            "path": "frontend-dev/frontend/bucket",
+            "uniqueId": "frontend_bucket_EFDC2F3F"
+          }
+        },
+        "bucket_prefix": "sls-example-frontend-development",
+        "tags": {
+          "hc-internet-facing": "true"
+        }
+      }
+    },
+    "aws_s3_bucket_policy": {
+      "frontend_s3_policy_42C30805": {
+        "//": {
+          "metadata": {
+            "path": "frontend-dev/frontend/s3_policy",
+            "uniqueId": "frontend_s3_policy_42C30805"
+          }
+        },
+        "bucket": "${aws_s3_bucket.frontend_bucket_EFDC2F3F.id}",
+        "policy": "{\"Version\":\"2012-10-17\",\"Id\":\"PolicyForWebsiteEndpointsPublicContent\",\"Statement\":[{\"Sid\":\"PublicRead\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":[\"s3:GetObject\"],\"Resource\":[\"${aws_s3_bucket.frontend_bucket_EFDC2F3F.arn}/*\",\"${aws_s3_bucket.frontend_bucket_EFDC2F3F.arn}\"]}]}"
+      }
+    },
+    "aws_s3_bucket_website_configuration": {
+      "frontend_website-configuration_53A72F76": {
+        "//": {
+          "metadata": {
+            "path": "frontend-dev/frontend/website-configuration",
+            "uniqueId": "frontend_website-configuration_53A72F76"
+          }
+        },
+        "bucket": "${aws_s3_bucket.frontend_bucket_EFDC2F3F.bucket}",
+        "error_document": {
+          "key": "index.html"
+        },
+        "index_document": {
+          "suffix": "index.html"
+        }
+      }
+    },
+    "local_file": {
+      "frontend_env_FADFC9DB": {
+        "//": {
+          "metadata": {
+            "path": "frontend-dev/frontend/env",
+            "uniqueId": "frontend_env_FADFC9DB"
+          }
+        },
+        "content": "S3_BUCKET_FRONTEND=${aws_s3_bucket.frontend_bucket_EFDC2F3F.bucket}\nREACT_APP_API_ENDPOINT=${data.terraform_remote_state.cross-stack-reference-input-posts-dev.outputs.cross-stack-output-aws_apigatewayv2_apiposts_api_api-gw_B6634897api_endpoint}",
+        "filename": "cdktf-integration-serverless-example/frontend/code/.env.production.local"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "local": {
+        "path": "cdktf-integration-serverless-example/terraform.frontend-dev.tfstate"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "aws",
+        "version": "4.27.0"
+      },
+      "local": {
+        "source": "hashicorp/local",
+        "version": "2.2.3"
+      }
+    }
+  }
+}

--- a/pkg/input/golden_test/tf/cdktf.out/posts-dev.tf.json
+++ b/pkg/input/golden_test/tf/cdktf.out/posts-dev.tf.json
@@ -1,0 +1,155 @@
+{
+  "//": {
+    "metadata": {
+      "backend": "local",
+      "stackName": "posts-dev",
+      "version": "0.12.1"
+    },
+    "outputs": {
+      "posts-dev": {
+        "cross-stack-output-aws_apigatewayv2_api.posts_api_api-gw_B6634897.api_endpoint": "cross-stack-output-aws_apigatewayv2_apiposts_api_api-gw_B6634897api_endpoint"
+      }
+    }
+  },
+  "output": {
+    "cross-stack-output-aws_apigatewayv2_apiposts_api_api-gw_B6634897api_endpoint": {
+      "sensitive": true,
+      "value": "${aws_apigatewayv2_api.posts_api_api-gw_B6634897.api_endpoint}"
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "region": "eu-central-1"
+      }
+    ]
+  },
+  "resource": {
+    "aws_apigatewayv2_api": {
+      "posts_api_api-gw_B6634897": {
+        "//": {
+          "metadata": {
+            "path": "posts-dev/posts/api/api-gw",
+            "uniqueId": "posts_api_api-gw_B6634897"
+          }
+        },
+        "cors_configuration": {
+          "allow_headers": [
+            "content-type"
+          ],
+          "allow_methods": [
+            "*"
+          ],
+          "allow_origins": [
+            "*"
+          ]
+        },
+        "name": "sls-example-posts-development",
+        "protocol_type": "HTTP",
+        "target": "${aws_lambda_function.posts_api_7D5242CA.arn}"
+      }
+    },
+    "aws_dynamodb_table": {
+      "posts_storage_table_50F8EECB": {
+        "//": {
+          "metadata": {
+            "path": "posts-dev/posts/storage/table",
+            "uniqueId": "posts_storage_table_50F8EECB"
+          }
+        },
+        "attribute": [
+          {
+            "name": "id",
+            "type": "S"
+          },
+          {
+            "name": "postedAt",
+            "type": "S"
+          }
+        ],
+        "billing_mode": "PAY_PER_REQUEST",
+        "hash_key": "id",
+        "name": "sls-posts-development",
+        "range_key": "postedAt"
+      }
+    },
+    "aws_iam_role": {
+      "posts_api_lambda-exec_B42627E0": {
+        "//": {
+          "metadata": {
+            "path": "posts-dev/posts/api/lambda-exec",
+            "uniqueId": "posts_api_lambda-exec_B42627E0"
+          }
+        },
+        "assume_role_policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Principal\":{\"Service\":\"lambda.amazonaws.com\"},\"Effect\":\"Allow\",\"Sid\":\"\"}]}",
+        "inline_policy": [
+          {
+            "name": "AllowDynamoDB",
+            "policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Action\":[\"dynamodb:Scan\",\"dynamodb:Query\",\"dynamodb:BatchGetItem\",\"dynamodb:GetItem\",\"dynamodb:PutItem\"],\"Resource\":\"${aws_dynamodb_table.posts_storage_table_50F8EECB.arn}\",\"Effect\":\"Allow\"}]}"
+          }
+        ],
+        "name": "sls-example-post-api-lambda-exec-development"
+      }
+    },
+    "aws_iam_role_policy_attachment": {
+      "posts_api_lambda-managed-policy_460C9C52": {
+        "//": {
+          "metadata": {
+            "path": "posts-dev/posts/api/lambda-managed-policy",
+            "uniqueId": "posts_api_lambda-managed-policy_460C9C52"
+          }
+        },
+        "policy_arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "${aws_iam_role.posts_api_lambda-exec_B42627E0.name}"
+      }
+    },
+    "aws_lambda_function": {
+      "posts_api_7D5242CA": {
+        "//": {
+          "metadata": {
+            "path": "posts-dev/posts/api/api",
+            "uniqueId": "posts_api_7D5242CA"
+          }
+        },
+        "environment": {
+          "variables": {
+            "DYNAMODB_TABLE_NAME": "${aws_dynamodb_table.posts_storage_table_50F8EECB.name}"
+          }
+        },
+        "filename": "assets/posts_api_code_lambda-asset_7F9E9FED/5C0604B46739D015AEDB1BA83362F19D/archive.zip",
+        "function_name": "sls-example-posts-api-development",
+        "handler": "index.handler",
+        "role": "${aws_iam_role.posts_api_lambda-exec_B42627E0.arn}",
+        "runtime": "nodejs14.x",
+        "source_code_hash": "5C0604B46739D015AEDB1BA83362F19D"
+      }
+    },
+    "aws_lambda_permission": {
+      "posts_api_apigw-lambda_02C673B9": {
+        "//": {
+          "metadata": {
+            "path": "posts-dev/posts/api/apigw-lambda",
+            "uniqueId": "posts_api_apigw-lambda_02C673B9"
+          }
+        },
+        "action": "lambda:InvokeFunction",
+        "function_name": "${aws_lambda_function.posts_api_7D5242CA.function_name}",
+        "principal": "apigateway.amazonaws.com",
+        "source_arn": "${aws_apigatewayv2_api.posts_api_api-gw_B6634897.execution_arn}/*/*"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "local": {
+        "path": "cdktf-integration-serverless-example/terraform.posts-dev.tfstate"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "aws",
+        "version": "4.27.0"
+      }
+    }
+  }
+}

--- a/pkg/input/golden_test/tf/tfjson.json
+++ b/pkg/input/golden_test/tf/tfjson.json
@@ -1,0 +1,32 @@
+{
+  "format": "",
+  "format_version": "",
+  "input_type": "tf_hcl",
+  "environment_provider": "iac",
+  "meta": {
+    "filepath": "golden_test/tf/tfjson/main.tf.json"
+  },
+  "resources": {
+    "aws_s3_bucket": {
+      "aws_s3_bucket.foo": {
+        "id": "aws_s3_bucket.foo",
+        "resource_type": "aws_s3_bucket",
+        "namespace": "golden_test/tf/tfjson/main.tf.json",
+        "meta": {
+          "region": "us-east-1",
+          "terraform": {
+            "provider_config": {
+              "region": "us-east-1"
+            }
+          }
+        },
+        "attributes": {
+          "bucket": "foo"
+        }
+      }
+    }
+  },
+  "scope": {
+    "filepath": "golden_test/tf/tfjson/main.tf.json"
+  }
+}

--- a/pkg/input/golden_test/tf/tfjson/main.tf.json
+++ b/pkg/input/golden_test/tf/tfjson/main.tf.json
@@ -1,0 +1,14 @@
+{
+  "provider": {
+    "aws": {
+      "region": "us-east-1"
+    }
+  },
+  "resource": {
+    "aws_s3_bucket": {
+      "foo": {
+        "bucket": "foo"
+      }
+    }
+  }
+}

--- a/pkg/input/tf.go
+++ b/pkg/input/tf.go
@@ -18,6 +18,7 @@ package input
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/snyk/policy-engine/pkg/hcl_interpreter"
 	"github.com/snyk/policy-engine/pkg/models"
@@ -30,7 +31,7 @@ import (
 type TfDetector struct{}
 
 func (t *TfDetector) DetectFile(i *File, opts DetectOptions) (IACConfiguration, error) {
-	if !opts.IgnoreExt && i.Ext() != ".tf" {
+	if !opts.IgnoreExt && !hasTerraformExt(i.Path) {
 		return nil, fmt.Errorf("%w: %v", UnrecognizedFileExtension, i.Ext())
 	}
 	dir := filepath.Dir(i.Path)
@@ -50,7 +51,7 @@ func (t *TfDetector) DetectDirectory(i *Directory, opts DetectOptions) (IACConfi
 		return nil, err
 	}
 	for _, child := range children {
-		if c, ok := child.(*File); ok && c.Ext() == ".tf" {
+		if c, ok := child.(*File); ok && hasTerraformExt(c.Path) {
 			tfExists = true
 		}
 	}
@@ -143,4 +144,8 @@ func (c *HclConfiguration) Errors() []error {
 
 func (l *HclConfiguration) Type() *Type {
 	return TerraformHCL
+}
+
+func hasTerraformExt(path string) bool {
+	return strings.HasSuffix(path, ".tf") || strings.HasSuffix(path, ".tf.json")
 }


### PR DESCRIPTION
This PR adds support for `.tf.json` files to the existing TF detector. This is the extension that Terraform recognizes for its JSON syntax: https://www.terraform.io/language/syntax/json

> Terraform expects native syntax for files named with a `.tf` suffix, and JSON syntax for files named with a `.tf.json` suffix.

This will also enable us to support the output of `cdktf synth`.