### PR TITLE
fix: duplicate resource IDs in tfstate

### DIFF
--- a/changes/unreleased/Fixed-20220928-180822.yaml
+++ b/changes/unreleased/Fixed-20220928-180822.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: duplicate resource IDs in tfstate
+time: 2022-09-28T18:08:22.56232-04:00

--- a/pkg/input/golden_test/tfstate/data-01.json
+++ b/pkg/input/golden_test/tfstate/data-01.json
@@ -5,8 +5,8 @@
   "environment_provider": "aws",
   "resources": {
     "data.aws_iam_policy_document": {
-      "2176800992": {
-        "id": "2176800992",
+      "data.aws_iam_policy_document.denied": {
+        "id": "data.aws_iam_policy_document.denied",
         "resource_type": "data.aws_iam_policy_document",
         "namespace": "aws",
         "meta": {

--- a/pkg/input/golden_test/tfstate/ids-01.json
+++ b/pkg/input/golden_test/tfstate/ids-01.json
@@ -5,8 +5,8 @@
   "environment_provider": "aws",
   "resources": {
     "aws_s3_bucket": {
-      "terraform-20220704200619858700000001": {
-        "id": "terraform-20220704200619858700000001",
+      "aws_s3_bucket.bucket1": {
+        "id": "aws_s3_bucket.bucket1",
         "resource_type": "aws_s3_bucket",
         "namespace": "aws",
         "meta": {
@@ -60,8 +60,8 @@
       }
     },
     "aws_s3_bucket_acl": {
-      "terraform-20220704200619858700000001,log-delivery-write": {
-        "id": "terraform-20220704200619858700000001,log-delivery-write",
+      "aws_s3_bucket_acl.acl1": {
+        "id": "aws_s3_bucket_acl.acl1",
         "resource_type": "aws_s3_bucket_acl",
         "namespace": "aws",
         "meta": {
@@ -126,8 +126,8 @@
       }
     },
     "aws_s3_bucket_logging": {
-      "terraform-20220704200619858700000001": {
-        "id": "terraform-20220704200619858700000001",
+      "aws_s3_bucket_logging.logging1": {
+        "id": "aws_s3_bucket_logging.logging1",
         "resource_type": "aws_s3_bucket_logging",
         "namespace": "aws",
         "meta": {

--- a/pkg/input/tfstate.go
+++ b/pkg/input/tfstate.go
@@ -104,6 +104,12 @@ func (l *tfstateLoader) ToState() models.State {
 			resourceType = "data." + resourceType
 		}
 
+		resourceName := resource.Name
+		resourceID := strings.Join([]string{
+			resourceType,
+			resourceName,
+		}, ".")
+
 		// Parse env provider
 		if environmentProvider == "" {
 			environmentProvider = strings.SplitN(resource.Type, "_", 2)[0]
@@ -118,25 +124,14 @@ func (l *tfstateLoader) ToState() models.State {
 		}
 
 		// Ensure attributes are available
-		if len(resource.Instances) < 0 {
+		if len(resource.Instances) < 1 {
 			continue
 		}
 		instance := resource.Instances[0]
 
-		// Parse ID
-		id := ""
-		if val, ok := instance.Attributes["id"]; ok {
-			if v, ok := val.(string); ok {
-				id = v
-			}
-		}
-		if id == "" {
-			continue
-		}
-
 		// Put it all together
 		resources = append(resources, models.ResourceState{
-			Id:           id,
+			Id:           resourceID,
 			ResourceType: resourceType,
 			Namespace:    resourceProvider,
 			Attributes:   instance.Attributes,


### PR DESCRIPTION
This PR resolves an issue with duplicate resource IDs from the tfstate detector. There are some resource types where `id` can be non-unique. Using `<resource_type>.<resource_name>` produces unique IDs that match our HCL and tfplan detectors.