### PR TITLE
feat: retain physical id when defined and add _id attribute

### DIFF
--- a/changes/unreleased/Added-20220930-105218.yaml
+++ b/changes/unreleased/Added-20220930-105218.yaml
@@ -1,0 +1,4 @@
+kind: Added
+body: _id attribute that always contains logical ID and retain physical ID when defined
+  in the id attribute
+time: 2022-09-30T10:52:18.374808-04:00

--- a/docs/policy_spec.md
+++ b/docs/policy_spec.md
@@ -410,6 +410,7 @@ $ ./policy-engine repl examples/main.tf
     "_provider": "aws",
     "_tags": {},
     "_type": "aws_cloudtrail",
+    "_id": "aws_cloudtrail.cloudtrail1",
     "id": "aws_cloudtrail.cloudtrail1",
     "include_global_service_events": true,
     "name": "cloudtrail1",
@@ -630,6 +631,7 @@ would become the following resource object:
   "_provider": "aws",
   "_tags": {},
   "_type": "aws_cloudtrail",
+  "_id": "aws_cloudtrail.cloudtrail1",
   "id": "aws_cloudtrail.cloudtrail1",
   "include_global_service_events": true,
   "name": "cloudtrail1",
@@ -638,8 +640,17 @@ would become the following resource object:
 }
 ```
 
-In general, policies will not need to interact with the added properties apart from
-`id`, which can be useful wherever a resource identifier is needed.
+Policy Engine adds two ID fields to the resource object that policies can use in
+their assertions:
+
+* `_id`: this will always contain the "logical ID" of the resource
+  * In IaC, logical IDs are typically how resources are referenced in the source
+    code.
+  * The example above demonstrates a logical ID from Terraform
+* `id`: this will contain the resource's `id` attribute if: it exists, it is
+  non-null, and it is non-blank. Otherwise, it will contain the logical ID.
+  * This flexibility can be helpful for writing assertions that work with both
+    IaC and deployed resources.
 
 #### Obtaining resource objects
 

--- a/rego/snyk.rego
+++ b/rego/snyk.rego
@@ -25,7 +25,6 @@ __physical_or_logical_id(resource) = ret {
 resources(resource_type) = ret {
 	ret := [obj |
 		resource := input.resources[resource_type][_]
-		# id := object.get(resource.attributes, "id", resource.id)
 		obj := object.union(
 			resource.attributes,
 			{

--- a/rego/snyk.rego
+++ b/rego/snyk.rego
@@ -14,13 +14,23 @@
 
 package snyk
 
+__physical_or_logical_id(resource) = ret {
+	is_string(resource.attributes.id)
+	not resource.attributes.id == ""
+	ret := resource.attributes.id
+} else = ret {
+	ret := resource.id
+}
+
 resources(resource_type) = ret {
 	ret := [obj |
 		resource := input.resources[resource_type][_]
+		# id := object.get(resource.attributes, "id", resource.id)
 		obj := object.union(
 			resource.attributes,
 			{
-				"id": resource.id,
+				"id": __physical_or_logical_id(resource),
+				"_id": resource.id,
 				"_type": resource_type,
 				"_namespace": resource.namespace,
 				"_meta": object.get(resource, "meta", {}),

--- a/rego/snyk_test.rego
+++ b/rego/snyk_test.rego
@@ -17,13 +17,34 @@ package snyk_test
 import data.snyk
 
 test_resource_id {
-	# Test that we override any "id" set in the attributes, which is how the
-	# Go code behaves.
-	mock_input := {"resources": {"aws_s3_bucket": {"aws_s3_bucket.foo": {
-		"id": "aws_s3_bucket.foo",
-		"namespace": "test.plan",
-		"attributes": {"id": "bar"},
-	}}}}
-	buckets = snyk.resources("aws_s3_bucket") with input as mock_input
-	buckets[_].id == "aws_s3_bucket.foo"
+	# Test that we set id and _id in the same way as the Go code. For id, that's:
+	#		* use the physical ID if one is defined
+	#		* otherwise use the logical ID
+	# And _id should always be set to the logical ID.
+	mock_input := {"resources": {"aws_s3_bucket": {
+		"aws_s3_bucket.foo": {
+			"id": "aws_s3_bucket.foo",
+			"namespace": "test.plan",
+			"attributes": {"id": "bar"},
+		},
+		"aws_s3_bucket.baz": {
+			"id": "aws_s3_bucket.baz",
+			"namespace": "test.plan",
+			"attributes": {"id": null},
+		},
+		"aws_s3_bucket.qux": {
+			"id": "aws_s3_bucket.qux",
+			"namespace": "test.plan",
+			"attributes": {},
+		},
+	}}}
+
+	buckets_by_logical_id := {id: bucket |
+		bucket := snyk.resources("aws_s3_bucket")[_]
+		id := bucket._id
+	} with input as mock_input
+
+	buckets_by_logical_id["aws_s3_bucket.foo"].id == "bar"
+	buckets_by_logical_id["aws_s3_bucket.baz"].id == "aws_s3_bucket.baz"
+	buckets_by_logical_id["aws_s3_bucket.qux"].id == "aws_s3_bucket.qux"
 }


### PR DESCRIPTION
This PR changes the way the resource's `id` property is set in our Rego API so that it will contain the "physical ID" if one is defined. Otherwise, it will be set to the logical ID.

We've also added an `_id` attribute which will _always_ be set to the "logical ID". In general, we should use `_id` when dealing with Terraform data resources.