### PR TITLE
chore: determinism for output

### DIFF
--- a/changes/unreleased/Changed-20221003-182712.yaml
+++ b/changes/unreleased/Changed-20221003-182712.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: ensure all arrays in output are deterministically sorted
+time: 2022-10-03T18:27:12.211280871+02:00

--- a/pkg/input/golden_test.go
+++ b/pkg/input/golden_test.go
@@ -17,14 +17,12 @@ package input
 
 import (
 	"encoding/json"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/spf13/afero"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/snyk/policy-engine/test/utils"
 )
 
 type goldenTest struct {
@@ -72,13 +70,6 @@ func LoadDirOrContents(t *testing.T, dir Directory, detector Detector) IACConfig
 }
 
 func TestGolden(t *testing.T) {
-	fixTests := false
-	for _, arg := range os.Args {
-		if arg == "golden-test-fix" {
-			fixTests = true
-		}
-	}
-
 	goldenTests, err := listGoldenTests()
 	if err != nil {
 		t.Fatal(err)
@@ -103,21 +94,7 @@ func TestGolden(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			expectedBytes := []byte{}
-			if _, err := os.Stat(entry.expected); err == nil {
-				expectedBytes, _ = ioutil.ReadFile(entry.expected)
-				if err != nil {
-					t.Fatal(err)
-				}
-			}
-
-			actual := string(actualBytes)
-			expected := string(expectedBytes)
-			assert.Equal(t, expected, actual)
-
-			if fixTests {
-				ioutil.WriteFile(entry.expected, actualBytes, 0644)
-			}
+			utils.GoldenTest(t, entry.expected, actualBytes)
 		})
 	}
 }

--- a/pkg/policy/api.go
+++ b/pkg/policy/api.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"embed"
 	"fmt"
+	"sort"
 
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
@@ -324,5 +325,6 @@ func (b *Builtins) ResourceTypes() []string {
 	for rt := range b.resourcesQueried {
 		rts = append(rts, rt)
 	}
+	sort.Strings(rts)
 	return rts
 }

--- a/pkg/policy/base.go
+++ b/pkg/policy/base.go
@@ -496,6 +496,22 @@ func (k ResourceKey) Correlation() string {
 	return fmt.Sprintf("%s$%s$%s", escape(k.Namespace), escape(k.Type), escape(k.ID))
 }
 
+func (l ResourceKey) Less(r ResourceKey) bool {
+	if l.Namespace == r.Namespace {
+		if l.Type == r.Type {
+			if l.ID == r.ID {
+				return false
+			} else {
+				return l.ID < r.ID
+			}
+		} else {
+			return l.Type < r.Type
+		}
+	} else {
+		return l.Namespace < r.Namespace
+	}
+}
+
 func (resource *policyResultResource) Key() ResourceKey {
 	// NOTE: Why is 'ResourceType' a seperate thing from 'policyResultResource'?
 	// The idea is that the latter represents all the data that can be

--- a/pkg/policy/multi.go
+++ b/pkg/policy/multi.go
@@ -17,6 +17,7 @@ package policy
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/snyk/policy-engine/pkg/logging"
@@ -164,9 +165,15 @@ func processMultiDenyPolicyResult(
 		}
 	}
 
-	results := []models.RuleResult{}
-	for _, builder := range builders {
-		results = append(results, builder.toRuleResult())
+	// Ensure deterministic ordering of results.
+	results := make([]models.RuleResult, len(builders))
+	correlations := []string{}
+	for correlation := range builders {
+		correlations = append(correlations, correlation)
+	}
+	sort.Strings(correlations)
+	for i, correlation := range correlations {
+		results[i] = builders[correlation].toRuleResult()
 	}
 	return results, nil
 }

--- a/pkg/policy/ruleresultbuilder.go
+++ b/pkg/policy/ruleresultbuilder.go
@@ -101,10 +101,17 @@ func (builder *ruleResultBuilder) addResourceAttribute(
 }
 
 func (builder *ruleResultBuilder) toRuleResult() models.RuleResult {
-	// Gather resources.  TODO: sort?
+	// Gather resources.
+	resourceKeys := []ResourceKey{}
+	for k := range builder.resources {
+		resourceKeys = append(resourceKeys, k)
+	}
+	sort.Slice(resourceKeys, func(i, j int) bool {
+		return resourceKeys[i].Less(resourceKeys[j])
+	})
 	resources := []*models.RuleResultResource{}
-	for _, resource := range builder.resources {
-		resources = append(resources, resource)
+	for _, k := range resourceKeys {
+		resources = append(resources, builder.resources[k])
 	}
 
 	// Gather messages.

--- a/test/examples_test.go
+++ b/test/examples_test.go
@@ -1,0 +1,63 @@
+// Copyright 2022 Snyk Ltd
+// Copyright 2021 Fugue, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/policy-engine/pkg/data"
+	"github.com/snyk/policy-engine/pkg/engine"
+	"github.com/snyk/policy-engine/pkg/input"
+	"github.com/snyk/policy-engine/pkg/postprocess"
+	"github.com/snyk/policy-engine/test/utils"
+)
+
+func TestExamples(t *testing.T) {
+	providers := []data.Provider{
+		data.PureRegoLibProvider(),
+	}
+	providers = append(providers, data.LocalProvider("../examples/metadata/"))
+	providers = append(providers, data.LocalProvider("../examples/"))
+	detector, err := input.DetectorByInputTypes(
+		input.Types{input.Auto},
+	)
+	assert.NoError(t, err)
+	loader := input.NewLoader(detector)
+	fsys := afero.OsFs{}
+	detectable, err := input.NewDetectable(fsys, "../examples/main.tf")
+	assert.NoError(t, err)
+	_, err = loader.Load(detectable, input.DetectOptions{})
+	assert.NoError(t, err)
+	ctx := context.Background()
+	states := loader.ToStates()
+	eng, err := engine.NewEngine(ctx, &engine.EngineOptions{
+		Providers: providers,
+	})
+	assert.NoError(t, err)
+	results := eng.Eval(ctx, &engine.EvalOptions{
+		Inputs: states,
+	})
+	postprocess.AddSourceLocs(results, loader)
+
+	bytes, err := json.MarshalIndent(results, "  ", "  ")
+	assert.NoError(t, err)
+	utils.GoldenTest(t, "examples_test.json", bytes)
+}

--- a/test/examples_test.json
+++ b/test/examples_test.json
@@ -1,0 +1,1179 @@
+{
+    "format": "results",
+    "format_version": "1.0.0",
+    "results": [
+      {
+        "input": {
+          "format": "",
+          "format_version": "",
+          "input_type": "tf_hcl",
+          "environment_provider": "iac",
+          "meta": {
+            "filepath": "../examples/main.tf"
+          },
+          "resources": {
+            "aws_cloudtrail": {
+              "aws_cloudtrail.cloudtrail1": {
+                "id": "aws_cloudtrail.cloudtrail1",
+                "resource_type": "aws_cloudtrail",
+                "namespace": "../examples/main.tf",
+                "meta": {
+                  "location": [
+                    {
+                      "filepath": "../examples/main.tf",
+                      "line": 55,
+                      "column": 1
+                    }
+                  ],
+                  "region": "us-east-1",
+                  "terraform": {
+                    "provider_config": {
+                      "region": "us-east-1"
+                    }
+                  }
+                },
+                "attributes": {
+                  "include_global_service_events": true,
+                  "name": "cloudtrail1",
+                  "s3_bucket_name": "aws_s3_bucket.bucket1",
+                  "s3_key_prefix": "prefix"
+                }
+              }
+            },
+            "aws_kms_key": {
+              "aws_kms_key.key": {
+                "id": "aws_kms_key.key",
+                "resource_type": "aws_kms_key",
+                "namespace": "../examples/main.tf",
+                "meta": {
+                  "location": [
+                    {
+                      "filepath": "../examples/main.tf",
+                      "line": 24,
+                      "column": 1
+                    }
+                  ],
+                  "region": "us-east-1",
+                  "terraform": {
+                    "provider_config": {
+                      "region": "us-east-1"
+                    }
+                  }
+                },
+                "attributes": {
+                  "deletion_window_in_days": 10,
+                  "description": "This key is used to encrypt bucket objects"
+                }
+              }
+            },
+            "aws_s3_bucket": {
+              "aws_s3_bucket.aes_bucket": {
+                "id": "aws_s3_bucket.aes_bucket",
+                "resource_type": "aws_s3_bucket",
+                "namespace": "../examples/main.tf",
+                "meta": {
+                  "location": [
+                    {
+                      "filepath": "../examples/main.tf",
+                      "line": 41,
+                      "column": 1
+                    }
+                  ],
+                  "region": "us-east-1",
+                  "terraform": {
+                    "provider_config": {
+                      "region": "us-east-1"
+                    }
+                  }
+                },
+                "attributes": {
+                  "bucket": "i-use-aes-encryption"
+                }
+              },
+              "aws_s3_bucket.bucket1": {
+                "id": "aws_s3_bucket.bucket1",
+                "resource_type": "aws_s3_bucket",
+                "namespace": "../examples/main.tf",
+                "meta": {
+                  "location": [
+                    {
+                      "filepath": "../examples/main.tf",
+                      "line": 5,
+                      "column": 1
+                    }
+                  ],
+                  "region": "us-east-1",
+                  "terraform": {
+                    "provider_config": {
+                      "region": "us-east-1"
+                    }
+                  }
+                },
+                "attributes": {
+                  "bucket": "dumb-bucket"
+                }
+              },
+              "aws_s3_bucket.bucket2": {
+                "id": "aws_s3_bucket.bucket2",
+                "resource_type": "aws_s3_bucket",
+                "namespace": "../examples/main.tf",
+                "meta": {
+                  "location": [
+                    {
+                      "filepath": "../examples/main.tf",
+                      "line": 9,
+                      "column": 1
+                    }
+                  ],
+                  "region": "us-east-1",
+                  "terraform": {
+                    "provider_config": {
+                      "region": "us-east-1"
+                    }
+                  }
+                },
+                "attributes": {
+                  "bucket": "dumb"
+                }
+              },
+              "aws_s3_bucket.bucket3": {
+                "id": "aws_s3_bucket.bucket3",
+                "resource_type": "aws_s3_bucket",
+                "namespace": "../examples/main.tf",
+                "meta": {
+                  "location": [
+                    {
+                      "filepath": "../examples/main.tf",
+                      "line": 29,
+                      "column": 1
+                    }
+                  ],
+                  "region": "us-east-1",
+                  "terraform": {
+                    "provider_config": {
+                      "region": "us-east-1"
+                    }
+                  }
+                },
+                "attributes": {
+                  "bucket": "bucket3",
+                  "server_side_encryption_configuration": [
+                    {
+                      "rule": [
+                        {
+                          "apply_server_side_encryption_by_default": [
+                            {
+                              "kms_master_key_id": "aws_kms_key.key",
+                              "sse_algorithm": "aws:kms"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
+            "aws_s3_bucket_server_side_encryption_configuration": {
+              "aws_s3_bucket_server_side_encryption_configuration.aes_bucket": {
+                "id": "aws_s3_bucket_server_side_encryption_configuration.aes_bucket",
+                "resource_type": "aws_s3_bucket_server_side_encryption_configuration",
+                "namespace": "../examples/main.tf",
+                "meta": {
+                  "location": [
+                    {
+                      "filepath": "../examples/main.tf",
+                      "line": 45,
+                      "column": 1
+                    }
+                  ],
+                  "region": "us-east-1",
+                  "terraform": {
+                    "provider_config": {
+                      "region": "us-east-1"
+                    }
+                  }
+                },
+                "attributes": {
+                  "bucket": "i-use-aes-encryption",
+                  "rule": [
+                    {
+                      "apply_server_side_encryption_by_default": [
+                        {
+                          "sse_algorithm": "AES256"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              "aws_s3_bucket_server_side_encryption_configuration.bucket2": {
+                "id": "aws_s3_bucket_server_side_encryption_configuration.bucket2",
+                "resource_type": "aws_s3_bucket_server_side_encryption_configuration",
+                "namespace": "../examples/main.tf",
+                "meta": {
+                  "location": [
+                    {
+                      "filepath": "../examples/main.tf",
+                      "line": 13,
+                      "column": 1
+                    }
+                  ],
+                  "region": "us-east-1",
+                  "terraform": {
+                    "provider_config": {
+                      "region": "us-east-1"
+                    }
+                  }
+                },
+                "attributes": {
+                  "bucket": "dumb",
+                  "rule": [
+                    {
+                      "apply_server_side_encryption_by_default": [
+                        {
+                          "kms_master_key_id": "aws_kms_key.key",
+                          "sse_algorithm": "aws:kms"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
+            "kubernetes_pod": {
+              "kubernetes_pod.multiple_containers": {
+                "id": "kubernetes_pod.multiple_containers",
+                "resource_type": "kubernetes_pod",
+                "namespace": "../examples/main.tf",
+                "meta": {
+                  "location": [
+                    {
+                      "filepath": "../examples/main.tf",
+                      "line": 62,
+                      "column": 1
+                    }
+                  ]
+                },
+                "attributes": {
+                  "metadata": [
+                    {
+                      "name": "multiple-containers"
+                    }
+                  ],
+                  "spec": [
+                    {
+                      "container": [
+                        {
+                          "env": [
+                            {
+                              "name": "environment",
+                              "value": "test"
+                            }
+                          ],
+                          "image": "nginx:1.7.9",
+                          "name": "example-allowed"
+                        },
+                        {
+                          "env": [
+                            {
+                              "name": "environment",
+                              "value": "test"
+                            }
+                          ],
+                          "image": "nginx:1.7.9",
+                          "name": "example-denied",
+                          "security_context": [
+                            {
+                              "privileged": true
+                            }
+                          ]
+                        },
+                        {
+                          "env": [
+                            {
+                              "name": "environment",
+                              "value": "test"
+                            }
+                          ],
+                          "image": "nginx:1.7.9",
+                          "name": "example-denied-2",
+                          "security_context": [
+                            {
+                              "privileged": true
+                            }
+                          ]
+                        }
+                      ],
+                      "init_container": [
+                        {
+                          "args": [
+                            "-c",
+                            "exit",
+                            "0"
+                          ],
+                          "command": [
+                            "/bin/sh"
+                          ],
+                          "env": [
+                            {
+                              "name": "environment",
+                              "value": "test"
+                            }
+                          ],
+                          "image": "nginx:1.7.9",
+                          "name": "example-denied-init",
+                          "security_context": [
+                            {
+                              "privileged": true
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "scope": {
+            "filepath": "../examples/main.tf"
+          }
+        },
+        "rule_results": [
+          {
+            "id": "COMPANY_0001",
+            "title": "S3 bucket name contains the word 'bucket'",
+            "platform": [
+              "AWS"
+            ],
+            "description": "It is unnecessary for resource names to contain their type.",
+            "references": [
+              {
+                "url": "https://example.com/bucket-naming-conventions",
+                "title": "Some blog post"
+              },
+              {
+                "url": "https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket",
+                "title": "Resource: aws_s3_bucket"
+              }
+            ],
+            "category": "Best Practices",
+            "labels": [
+              "Naming Conventions",
+              "Pet Peeves"
+            ],
+            "service_group": "S3",
+            "controls": {
+              "CIS-AWS": {
+                "v1.3.0": [
+                  "5.1",
+                  "5.2"
+                ],
+                "v1.4.0": [
+                  "6.7"
+                ]
+              }
+            },
+            "resource_types": [
+              "aws_s3_bucket"
+            ],
+            "results": [
+              {
+                "passed": true,
+                "ignored": false,
+                "resource_id": "aws_s3_bucket.aes_bucket",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "severity": "Critical",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.aes_bucket",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 41,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "passed": false,
+                "ignored": false,
+                "message": "Bucket names should not contain the word bucket, it's implied",
+                "resource_id": "aws_s3_bucket.bucket1",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "remediation": "1. Find the corresponding aws_s3_bucket resource\n2. ...",
+                "severity": "Critical",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.bucket1",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 5,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "passed": true,
+                "ignored": false,
+                "resource_id": "aws_s3_bucket.bucket2",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "severity": "Critical",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.bucket2",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 9,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "passed": false,
+                "ignored": false,
+                "message": "Bucket names should not contain the word bucket, it's implied",
+                "resource_id": "aws_s3_bucket.bucket3",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "remediation": "1. Find the corresponding aws_s3_bucket resource\n2. ...",
+                "severity": "Critical",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.bucket3",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 29,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "package": "data.rules.snyk_001.tf"
+          },
+          {
+            "resource_types": [
+              "aws_s3_bucket"
+            ],
+            "results": [
+              {
+                "passed": true,
+                "ignored": false,
+                "resource_id": "aws_s3_bucket.aes_bucket",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.aes_bucket",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 41,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "passed": false,
+                "ignored": false,
+                "message": "Bucket names should not contain the word bucket, it's implied",
+                "resource_id": "aws_s3_bucket.bucket1",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.bucket1",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 5,
+                        "column": 1
+                      }
+                    ],
+                    "attributes": [
+                      {
+                        "path": [
+                          "bucket"
+                        ],
+                        "location": {
+                          "filepath": "../examples/main.tf",
+                          "line": 6,
+                          "column": 3
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "passed": true,
+                "ignored": false,
+                "resource_id": "aws_s3_bucket.bucket2",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.bucket2",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 9,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "passed": false,
+                "ignored": false,
+                "message": "Bucket names should not contain the word bucket, it's implied",
+                "resource_id": "aws_s3_bucket.bucket3",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.bucket3",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 29,
+                        "column": 1
+                      }
+                    ],
+                    "attributes": [
+                      {
+                        "path": [
+                          "bucket"
+                        ],
+                        "location": {
+                          "filepath": "../examples/main.tf",
+                          "line": 30,
+                          "column": 3
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "package": "data.rules.snyk_002.tf"
+          },
+          {
+            "resource_types": [
+              "aws_s3_bucket"
+            ],
+            "results": [
+              {
+                "passed": false,
+                "ignored": false,
+                "message": "Bucket names should not contain the word bucket, it's implied",
+                "resource_id": "aws_s3_bucket.bucket1",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.bucket1",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 5,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "passed": false,
+                "ignored": false,
+                "message": "Bucket names should not contain the word bucket, it's implied",
+                "resource_id": "aws_s3_bucket.bucket3",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.bucket3",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 29,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "package": "data.rules.snyk_003.tf"
+          },
+          {
+            "resource_types": [
+              "aws_s3_bucket"
+            ],
+            "results": [
+              {
+                "passed": true,
+                "ignored": false,
+                "resource_id": "aws_s3_bucket.aes_bucket",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.aes_bucket",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 41,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "passed": false,
+                "ignored": false,
+                "message": "Buckets should not contain bucket, it is implied",
+                "resource_id": "aws_s3_bucket.bucket1",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.bucket1",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 5,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "passed": true,
+                "ignored": false,
+                "resource_id": "aws_s3_bucket.bucket2",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.bucket2",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 9,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "passed": false,
+                "ignored": false,
+                "message": "Buckets should not contain bucket, it is implied",
+                "resource_id": "aws_s3_bucket.bucket3",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.bucket3",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 29,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "package": "data.rules.snyk_004.tf"
+          },
+          {
+            "resource_types": [
+              "aws_s3_bucket",
+              "aws_s3_bucket_server_side_encryption_configuration"
+            ],
+            "results": [
+              {
+                "passed": true,
+                "ignored": false,
+                "resource_id": "aws_s3_bucket.aes_bucket",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.aes_bucket",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 41,
+                        "column": 1
+                      }
+                    ]
+                  },
+                  {
+                    "id": "aws_s3_bucket_server_side_encryption_configuration.aes_bucket",
+                    "type": "aws_s3_bucket_server_side_encryption_configuration",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 45,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "passed": false,
+                "ignored": false,
+                "message": "Bucket does not specify encryption",
+                "resource_id": "aws_s3_bucket.bucket1",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.bucket1",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 5,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "passed": true,
+                "ignored": false,
+                "resource_id": "aws_s3_bucket.bucket2",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.bucket2",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 9,
+                        "column": 1
+                      }
+                    ]
+                  },
+                  {
+                    "id": "aws_s3_bucket_server_side_encryption_configuration.bucket2",
+                    "type": "aws_s3_bucket_server_side_encryption_configuration",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 13,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "passed": true,
+                "ignored": false,
+                "resource_id": "aws_s3_bucket.bucket3",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.bucket3",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 29,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "package": "data.rules.snyk_005.tf"
+          },
+          {
+            "resource_types": [
+              "aws_s3_bucket",
+              "aws_s3_bucket_server_side_encryption_configuration"
+            ],
+            "results": [
+              {
+                "passed": true,
+                "ignored": false,
+                "resource_id": "aws_s3_bucket.aes_bucket",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.aes_bucket",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 41,
+                        "column": 1
+                      }
+                    ]
+                  },
+                  {
+                    "id": "aws_s3_bucket_server_side_encryption_configuration.aes_bucket",
+                    "type": "aws_s3_bucket_server_side_encryption_configuration",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 45,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "passed": false,
+                "ignored": false,
+                "message": "Bucket does not specify encryption",
+                "resource_id": "aws_s3_bucket.bucket1",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.bucket1",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 5,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "passed": true,
+                "ignored": false,
+                "resource_id": "aws_s3_bucket.bucket2",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.bucket2",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 9,
+                        "column": 1
+                      }
+                    ]
+                  },
+                  {
+                    "id": "aws_s3_bucket_server_side_encryption_configuration.bucket2",
+                    "type": "aws_s3_bucket_server_side_encryption_configuration",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 13,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "passed": true,
+                "ignored": false,
+                "resource_id": "aws_s3_bucket.bucket3",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.bucket3",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 29,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "package": "data.rules.snyk_006.tf"
+          },
+          {
+            "resource_types": [
+              "kubernetes_pod"
+            ],
+            "results": [
+              {
+                "passed": false,
+                "ignored": false,
+                "message": "Pod contains container running in privileged mode",
+                "resource_id": "kubernetes_pod.multiple_containers",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "kubernetes_pod",
+                "resources": [
+                  {
+                    "id": "kubernetes_pod.multiple_containers",
+                    "type": "kubernetes_pod",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 62,
+                        "column": 1
+                      }
+                    ],
+                    "attributes": [
+                      {
+                        "path": [
+                          "spec",
+                          0,
+                          "container",
+                          1,
+                          "security_context",
+                          0,
+                          "privileged"
+                        ],
+                        "location": {
+                          "filepath": "../examples/main.tf",
+                          "line": 103,
+                          "column": 9
+                        }
+                      },
+                      {
+                        "path": [
+                          "spec",
+                          0,
+                          "container",
+                          2,
+                          "security_context",
+                          0,
+                          "privileged"
+                        ],
+                        "location": {
+                          "filepath": "../examples/main.tf",
+                          "line": 117,
+                          "column": 9
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "package": "data.rules.snyk_007.tf"
+          },
+          {
+            "description": "This is rule 7",
+            "resource_types": [
+              "aws_cloudtrail"
+            ],
+            "results": [
+              {
+                "passed": true,
+                "ignored": false,
+                "resource_id": "aws_cloudtrail.cloudtrail1",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_cloudtrail",
+                "resources": [
+                  {
+                    "id": "aws_cloudtrail.cloudtrail1",
+                    "type": "aws_cloudtrail",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 55,
+                        "column": 1
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "package": "data.rules.snyk_008.tf"
+          },
+          {
+            "resource_types": [
+              "aws_s3_bucket",
+              "aws_s3_bucket_server_side_encryption_configuration"
+            ],
+            "results": [
+              {
+                "passed": false,
+                "ignored": false,
+                "resource_id": "aws_s3_bucket.aes_bucket",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.aes_bucket",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 41,
+                        "column": 1
+                      }
+                    ]
+                  },
+                  {
+                    "id": "aws_s3_bucket_server_side_encryption_configuration.aes_bucket",
+                    "type": "aws_s3_bucket_server_side_encryption_configuration",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 45,
+                        "column": 1
+                      }
+                    ],
+                    "attributes": [
+                      {
+                        "path": [
+                          "rule",
+                          0,
+                          "apply_server_side_encryption_by_default",
+                          0
+                        ],
+                        "location": {
+                          "filepath": "../examples/main.tf",
+                          "line": 49,
+                          "column": 5
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "passed": true,
+                "ignored": false,
+                "resource_id": "aws_s3_bucket.bucket2",
+                "resource_namespace": "../examples/main.tf",
+                "resource_type": "aws_s3_bucket",
+                "resources": [
+                  {
+                    "id": "aws_s3_bucket.bucket2",
+                    "type": "aws_s3_bucket",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 9,
+                        "column": 1
+                      }
+                    ]
+                  },
+                  {
+                    "id": "aws_s3_bucket_server_side_encryption_configuration.bucket2",
+                    "type": "aws_s3_bucket_server_side_encryption_configuration",
+                    "namespace": "../examples/main.tf",
+                    "location": [
+                      {
+                        "filepath": "../examples/main.tf",
+                        "line": 13,
+                        "column": 1
+                      }
+                    ],
+                    "attributes": [
+                      {
+                        "path": [
+                          "rule",
+                          0,
+                          "apply_server_side_encryption_by_default",
+                          0
+                        ],
+                        "location": {
+                          "filepath": "../examples/main.tf",
+                          "line": 17,
+                          "column": 5
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "package": "data.rules.snyk_009.tf"
+          }
+        ]
+      }
+    ]
+  }

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -1,0 +1,53 @@
+// Copyright 2022 Snyk Ltd
+// Copyright 2021 Fugue, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var fixTests bool
+
+func init() {
+	for _, arg := range os.Args {
+		if arg == "golden-test-fix" {
+			fixTests = true
+		}
+	}
+}
+
+func GoldenTest(t *testing.T, expectedPath string, actualBytes []byte) {
+	expectedBytes := []byte{}
+	if _, err := os.Stat(expectedPath); err == nil {
+		expectedBytes, _ = ioutil.ReadFile(expectedPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	actual := string(actualBytes)
+	expected := string(expectedBytes)
+
+	if fixTests {
+		ioutil.WriteFile(expectedPath, actualBytes, 0644)
+	} else {
+		assert.Equal(t, expected, actual)
+	}
+}


### PR DESCRIPTION
I wanted to make it easier to test policy engine output for when I was working on determining attributes.

 -  Adds a `test/utils` package with a helper for golden tests, which I then used in `pkg/input/golden_test.go`

 -  A new test `test/examples_test.go` that also uses this golden test helper.  It runs all the files in `examples/`.

 -  Fight Go's random map iteration order wherever it matters.