### PR TITLE
Enable print() statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /policy-engine
 .scratch
 .vscode
+.idea

--- a/changes/unreleased/Fixed-20221004-191109.yaml
+++ b/changes/unreleased/Fixed-20221004-191109.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Enable `print()` statements in the `test` command
+time: 2022-10-04T19:11:09.515604+02:00

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -68,7 +68,10 @@ var testCmd = &cobra.Command{
 		capabilities := policy.Capabilities()
 		capabilities.Builtins = append(capabilities.Builtins, snapshot_testing.MatchBuiltin)
 
-		compiler := ast.NewCompiler().WithCapabilities(capabilities)
+		compiler := ast.NewCompiler().
+			WithCapabilities(capabilities).
+			WithEnablePrintStatements(true)
+
 		ch, err := tester.NewRunner().
 			AddCustomBuiltins([]*tester.Builtin{
 				{
@@ -84,7 +87,6 @@ var testCmd = &cobra.Command{
 				},
 			}).
 			SetCompiler(compiler).
-			CapturePrintOutput(true).
 			EnableTracing(*rootCmdVerbose).
 			SetStore(store).
 			SetModules(consumer.Modules).


### PR DESCRIPTION
This PR enables `print()` statements. The option `CapturePrintOutput()` on the test runner is a no-op, and in order for the output to be captured, it's necessary to enable the `WithEnablePrintStatements()` option on the compiler.