### PR TITLE
Use the configured Engine logger when evaluating policies

### DIFF
--- a/changes/unreleased/Fixed-20221005-114127.yaml
+++ b/changes/unreleased/Fixed-20221005-114127.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Use the configured Engine logger when evaluating policies
+time: 2022-10-05T11:41:27.732192+02:00

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -185,6 +185,7 @@ func (e *Engine) Eval(ctx context.Context, options *EvalOptions) *models.Results
 			Input:             &state,
 			InputValue:        value,
 			ResourcesResolver: options.ResourcesResolver,
+			Logger:            e.logger,
 		}
 		allRuleResults := []models.RuleResults{}
 		policyChan := make(chan policy.Policy)


### PR DESCRIPTION
The `Logger` configured on the `Engine` was not correctly propagated into the `EvalOptions`. In case of errors, log messages were sent to the default logger (stderr) instead of to the configured one.