### PR TITLE
Return a FailedToParseInput error if an HCL evaluation fails

### DIFF
--- a/changes/unreleased/Fixed-20221019-144350.yaml
+++ b/changes/unreleased/Fixed-20221019-144350.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Return a FailedToParseInput error if an HCL evaluation fails
+time: 2022-10-19T14:43:50.888984+02:00

--- a/pkg/input/tf.go
+++ b/pkg/input/tf.go
@@ -78,7 +78,7 @@ func newHclConfiguration(moduleTree *hcl_interpreter.ModuleTree) (*HclConfigurat
 	analysis := hcl_interpreter.AnalyzeModuleTree(moduleTree)
 	evaluation, err := hcl_interpreter.EvaluateAnalysis(analysis)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%w: %v", FailedToParseInput, err)
 	}
 
 	resources := evaluation.Resources()


### PR DESCRIPTION
When an HCL evaluation fails, the Policy Engine should return a `FailedToParseInput` error, so callers can properly handle it.