### PR TITLE
fix: CLOUD-972 use _id in rule result builder

### DIFF
--- a/changes/unreleased/Fixed-20221103-160316.yaml
+++ b/changes/unreleased/Fixed-20221103-160316.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: mismatch between resource_id in rule results and Resource.ID
+time: 2022-11-03T16:03:16.551573-04:00

--- a/pkg/policy/base.go
+++ b/pkg/policy/base.go
@@ -419,7 +419,7 @@ func unmarshalResultSet(resultSet rego.ResultSet, v interface{}) error {
 }
 
 type policyResultResource struct {
-	ID           string `json:"id"`
+	ID           string `json:"_id"`
 	ResourceType string `json:"_type"`
 	Namespace    string `json:"_namespace"`
 }


### PR DESCRIPTION
This PR changes the ID that we use when we deserialize rule results after evaluation. The `_id` property will always be the `Resource.ID`, whereas the `id` property can come from the resource's attributes if they have an `id` property. Consumers always expect that we return the `Resource.ID` in the `resource_id` field in rule results, so this change fulfills that expectation.