### PR TITLE
feat: capture unset attributes in tracer

### DIFF
--- a/pkg/policy/api.go
+++ b/pkg/policy/api.go
@@ -211,11 +211,11 @@ func (r *resourcesByType) impl(
 	ret := [][2]*ast.Term{}
 	if resources, ok := r.input.Resources[rt]; ok {
 		for resourceKey, resource := range resources {
-			val, err := resourceStateToRegoInput(resource)
+			resource, err := resourceStateToRegoInput(resource)
 			if err != nil {
 				return nil, err
 			}
-			ret = append(ret, [2]*ast.Term{ast.StringTerm(resourceKey), ast.NewTerm(val)})
+			ret = append(ret, [2]*ast.Term{ast.StringTerm(resourceKey), resource})
 		}
 	}
 	term := ast.ObjectTerm(ret...)
@@ -223,7 +223,7 @@ func (r *resourcesByType) impl(
 	return term, nil
 }
 
-func resourceStateToRegoInput(resource models.ResourceState) (ast.Value, error) {
+func resourceStateToRegoInput(resource models.ResourceState) (*ast.Term, error) {
 	obj := map[string]interface{}{}
 	obj["id"] = resource.Id
 	obj["_id"] = resource.Id
@@ -250,18 +250,19 @@ func resourceStateToRegoInput(resource models.ResourceState) (ast.Value, error) 
 	if err != nil {
 		return nil, err
 	}
-	inferattributes.DecorateResource(resource, val)
-	return val, nil
+	term := ast.NewTerm(val)
+	inferattributes.DecorateResource(resource, term)
+	return term, nil
 }
 
 func resourceStatesToRegoInputs(resources []models.ResourceState) ([]*ast.Term, error) {
 	ret := make([]*ast.Term, len(resources))
 	for i, resource := range resources {
-		val, err := resourceStateToRegoInput(resource)
+		term, err := resourceStateToRegoInput(resource)
 		if err != nil {
 			return nil, err
 		}
-		ret[i] = ast.NewTerm(val)
+		ret[i] = term
 	}
 	return ret, nil
 }

--- a/pkg/policy/inferattributes/resource.go
+++ b/pkg/policy/inferattributes/resource.go
@@ -22,16 +22,16 @@ import (
 	"github.com/snyk/policy-engine/pkg/models"
 )
 
-// DecorateResource is a helper that sets up DecorateValue in a way that we
+// DecorateResource is a helper that sets up DecorateTerm in a way that we
 // will be able to tell which resource the values belonged to.
-func DecorateResource(resource models.ResourceState, value ast.Value) {
+func DecorateResource(resource models.ResourceState, term *ast.Term) {
 	prefix := []interface{}{
 		resource.Namespace,
 		resource.ResourceType,
 		resource.Id,
 	}
 
-	DecorateValue(prefix, value)
+	DecorateTerm(prefix, term)
 }
 
 // byResource extracts the accessed attributes from the underlying pathset.
@@ -42,11 +42,11 @@ func (tracer *Tracer) byResource() map[[3]string][][]interface{} {
 
 	// Do not include paths starting with these fields.
 	mask1 := map[string]struct{}{
-		"id":         struct{}{},
-		"_id":        struct{}{},
-		"_meta":      struct{}{},
-		"_namespace": struct{}{},
-		"_type":      struct{}{},
+		"id":         {},
+		"_id":        {},
+		"_meta":      {},
+		"_namespace": {},
+		"_type":      {},
 	}
 
 	for _, inputPath := range tracer.pathSet.List() {
@@ -67,9 +67,8 @@ func (tracer *Tracer) byResource() map[[3]string][][]interface{} {
 									continue
 								}
 							}
+							resources[key] = append(resources[key], attribute)
 						}
-
-						resources[key] = append(resources[key], attribute)
 					}
 				}
 			}
@@ -78,7 +77,7 @@ func (tracer *Tracer) byResource() map[[3]string][][]interface{} {
 	return resources
 }
 
-// InferAttributes decorates the given rule results with any attribtes that
+// InferAttributes decorates the given rule results with any attributes that
 // have been accessed; using the resource identifiers to correlate them.
 func (tracer *Tracer) InferAttributes(ruleResult []models.RuleResult) {
 	resources := tracer.byResource()

--- a/pkg/policy/single.go
+++ b/pkg/policy/single.go
@@ -100,7 +100,10 @@ func (p *SingleResourcePolicy) Eval(
 				output.Errors = append(output.Errors, err.Error())
 				return []models.RuleResults{output}, err
 			}
-			resultSet, err := query.Eval(ctx, rego.EvalQueryTracer(tracer), rego.EvalParsedInput(inputDoc))
+			// TODO: We need a different strategy for unset properties in single-resource rules. The
+			// problem is that we lose the top-level location on the term. We might be able to use
+			// the fact that the term references `input` instead.
+			resultSet, err := query.Eval(ctx, rego.EvalQueryTracer(tracer), rego.EvalParsedInput(inputDoc.Value))
 			if err != nil {
 				logger.Error(ctx, "Failed to evaluate rule for resource")
 				err = fmt.Errorf("%w '%s': %v", FailedToEvaluateResource, resource.Id, err)


### PR DESCRIPTION
This PR modifies the attribute access tracer to capture unset attributes and single-term expressions, like `not resource.some_attribute`. There are two main components to this change:

1. Alter the `Decorate...` functions add `Location` to both the resource attributes and the resource itself.
2. Build out as much of the attribute paths as we can resolve in `coverTerm`. Previously, we were ignoring non-ground terms or terms that did not have an encoded `Location` attribute.

# Caveats

* This feature will not work properly in single-resource rules. We're not able to decorate the `input` term, so we'll need to do some followup work to check for `input` in refs. This might be a good reason to split up the single and  multi-rule tracers into separate components.
* This change is _mostly_ additive, meaning that in comparison with the latest version (v0.12.1) it adds attributes that were not previously being captured by the tracer. The exceptions are:
  * There is a bug in the current `POLICY_ENGINE_FORCE_INFER_ATTRIBUTES` behavior (fixed in this PR) which does not force infer attributes if the inferred attributes are empty. This throws off the comparison.
  * We get inconsistent inferred attributes across runs for some rules. This bug is present in both the latest version and in this PR, so I consider it to be followup work. It's possible that there's some non-deterministic behavior in OPA that throws this off.


