### PR TITLE
fix: return empty arrays from snyk.[back_]relates

### DIFF
--- a/changes/unreleased/Fixed-20221208-124721.yaml
+++ b/changes/unreleased/Fixed-20221208-124721.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: return empty arrays from snyk.(back_)relates if nothing found
+time: 2022-12-08T12:47:21.923834921+01:00

--- a/rego/snyk/internal/relations_test.rego
+++ b/rego/snyk/internal/relations_test.rego
@@ -29,6 +29,11 @@ check_relations {
 		count(acl_bucket_acl) == 1
 		acl_bucket_acl[_] == acl
 	}
+
+	# Check that we return empty arrays when appropriate.
+	non_existing_relation := snyk.relates(bucket_1, "bucket_foobar")
+	is_array(non_existing_relation)
+	count(non_existing_relation) == 0
 }
 
 test_relations {

--- a/rego/snyk/relations.rego
+++ b/rego/snyk/relations.rego
@@ -4,8 +4,12 @@ import data.snyk.internal.relations
 
 relates(resource, name) = ret {
 	ret := relations.forward[[name, relations.make_resource_key(resource)]]
+} else = [] {
+	true
 }
 
 back_relates(name, resource) = ret {
 	ret := relations.backward[[name, relations.make_resource_key(resource)]]
+} else = [] {
+	true
 }


### PR DESCRIPTION
This is what's in the spec, and it leads to less surprising results if you do things like `count(_)==0`.