### PR TITLE
fix: return non-zero if a command throws error

### DIFF
--- a/changes/unreleased/Fixed-20221213-132318.yaml
+++ b/changes/unreleased/Fixed-20221213-132318.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Return non-zero exit code on error
+time: 2022-12-13T13:23:18.182824-05:00

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,11 +49,7 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() error {
-	err := rootCmd.Execute()
-	if err != nil {
-		os.Exit(2)
-	}
-	return nil
+	return rootCmd.Execute()
 }
 
 func cmdLogger() logging.Logger {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,11 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() error {
-	return rootCmd.Execute()
+	err := rootCmd.Execute()
+	if err != nil {
+		os.Exit(2)
+	}
+	return nil
 }
 
 func cmdLogger() logging.Logger {

--- a/main.go
+++ b/main.go
@@ -15,9 +15,13 @@
 package main
 
 import (
+	"os"
+
 	"github.com/snyk/policy-engine/cmd"
 )
 
 func main() {
-	cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		os.Exit(2)
+	}
 }


### PR DESCRIPTION
This change returns a non-zero exit code when an error occurs.

# Examples

## Unknown command

Old:

```
± policy-engine foo
Error: unknown command "foo" for "policy-engine"
Run 'policy-engine --help' for usage.
± echo $?
0
```

New:

```
± policy-engine foo
Error: unknown command "foo" for "policy-engine"
Run 'policy-engine --help' for usage.
± echo $?
2
```

## Unknown parameter

Old:

```
± policy-engine test -p -d rego/lib
Error: unknown shorthand flag: 'p' in -p
Usage:
  policy-engine test [flags]

Flags:
  -f, --filter string      Regular expression to filter tests by.
  -h, --help               help for test
      --update-snapshots   Updates snapshots used in snapshot_testing.match

Global Flags:
  -d, --data strings   Rego paths to load
  -v, --verbose        Sets log level to DEBUG

± echo $?
0
```

New:

```
± policy-engine test -p -d rego/lib
Error: unknown shorthand flag: 'p' in -p
Usage:
  policy-engine test [flags]

Flags:
  -f, --filter string      Regular expression to filter tests by.
  -h, --help               help for test
      --update-snapshots   Updates snapshots used in snapshot_testing.match

Global Flags:
  -d, --data strings   Rego paths to load
  -v, --verbose        Sets log level to DEBUG

± echo $?
2
```

## Failed to run tests due to bad compilation

Old:

```
± policy-engine test -d rego/lib -d rego/rules/SNYK_CC_00001
Error: 6 errors occurred:
rego/rules/SNYK_CC_00001/terraform_test.rego:8: rego_unsafe_var_error: var resources is unsafe
rego/rules/SNYK_CC_00001/terraform_test.rego:8: rego_unsafe_var_error: var deny is unsafe
rego/rules/SNYK_CC_00001/terraform_test.rego:25: rego_unsafe_var_error: var deny is unsafe
rego/rules/SNYK_CC_00001/terraform_test.rego:25: rego_unsafe_var_error: var resources is unsafe
rego/rules/SNYK_CC_00001/terraform_test.rego:42: rego_unsafe_var_error: var deny is unsafe
rego/rules/SNYK_CC_00001/terraform_test.rego:42: rego_unsafe_var_error: var resources is unsafe
Usage:
  policy-engine test [flags]

Flags:
  -f, --filter string      Regular expression to filter tests by.
  -h, --help               help for test
      --update-snapshots   Updates snapshots used in snapshot_testing.match

Global Flags:
  -d, --data strings   Rego paths to load
  -v, --verbose        Sets log level to DEBUG

± echo $?
0
```

New:

```
± policy-engine test -d rego/lib -d rego/rules/SNYK_CC_00001
Error: 6 errors occurred:
rego/rules/SNYK_CC_00001/terraform_test.rego:8: rego_unsafe_var_error: var deny is unsafe
rego/rules/SNYK_CC_00001/terraform_test.rego:8: rego_unsafe_var_error: var resources is unsafe
rego/rules/SNYK_CC_00001/terraform_test.rego:25: rego_unsafe_var_error: var deny is unsafe
rego/rules/SNYK_CC_00001/terraform_test.rego:25: rego_unsafe_var_error: var resources is unsafe
rego/rules/SNYK_CC_00001/terraform_test.rego:42: rego_unsafe_var_error: var resources is unsafe
rego/rules/SNYK_CC_00001/terraform_test.rego:42: rego_unsafe_var_error: var deny is unsafe
Usage:
  policy-engine test [flags]

Flags:
  -f, --filter string      Regular expression to filter tests by.
  -h, --help               help for test
      --update-snapshots   Updates snapshots used in snapshot_testing.match

Global Flags:
  -d, --data strings   Rego paths to load
  -v, --verbose        Sets log level to DEBUG

± echo $?
2
```

## Tests failed due to snapshot mismatch (no change)

Old:

```
± policy-engine-old test -d rego/lib -d rego/rules/SNYK_CC_00001
rego/rules/SNYK_CC_00001/terraform_test.rego:46: snapshots do not match:
--- rego/rules/SNYK_CC_00001/snapshots/terraform/valid_public_accessible.state.json
+++ actual
@@ -3,7 +3,7 @@
...
-        "resource": "aws_db_instance.foo"
+        "resource": "aws_db_instance.default"
...
rego/rules/SNYK_CC_00001/terraform_test.rego:
data.rules.SNYK_CC_00001.terraform.test_valid_public_accessible: FAIL (825.03µs)
--------------------------------------------------------------------------------
PASS: 22/23
FAIL: 1/23
± echo $?
1
```

New:

```
± policy-engine test -d rego/lib -d rego/rules/SNYK_CC_00001
rego/rules/SNYK_CC_00001/terraform_test.rego:46: snapshots do not match:
--- rego/rules/SNYK_CC_00001/snapshots/terraform/valid_public_accessible.state.json
+++ actual
@@ -3,7 +3,7 @@
...
-        "resource": "aws_db_instance.foo"
+        "resource": "aws_db_instance.default"
...
rego/rules/SNYK_CC_00001/terraform_test.rego:
data.rules.SNYK_CC_00001.terraform.test_valid_public_accessible: FAIL (831.646µs)
--------------------------------------------------------------------------------
PASS: 22/23
FAIL: 1/23
± echo $?
1
```

## Failed to run due to bad compilation

Old:

```
± policy-engine-old run -d rego/lib -d rego/rules/SNYK_CC_00001/terraform.rego infra.tf
1:12PM INF Initializing engine
1:12PM INF Finished consuming providers data_documents=15 modules=46
1:12PM ERR Failed during compilation
Error: Failed to compile rules: 8 errors occurred:
...
Usage:
  policy-engine run [-d <rules/metadata>...] [-r <rule ID>...] <input> [input...] [flags]

Flags:
  -h, --help               help for run
  -r, --rule strings       Select specific rules
      --var-file strings   Pass in variable files
  -w, --workers int        Number of workers. When 0 (the default) will use num CPUs + 1.

Global Flags:
  -d, --data strings   Rego paths to load
  -v, --verbose        Sets log level to DEBUG

± echo $?
0
```

New:

```
± policy-engine run -d rego/lib -d rego/rules/SNYK_CC_00001/terraform.rego infra.tf
1:13PM INF Initializing engine
1:13PM INF Finished consuming providers data_documents=15 modules=46
1:13PM ERR Failed during compilation
Error: Failed to compile rules: 8 errors occurred:
...
Usage:
  policy-engine run [-d <rules/metadata>...] [-r <rule ID>...] <input> [input...] [flags]

Flags:
  -h, --help               help for run
  -r, --rule strings       Select specific rules
      --var-file strings   Pass in variable files
  -w, --workers int        Number of workers. When 0 (the default) will use num CPUs + 1.

Global Flags:
  -d, --data strings   Rego paths to load
  -v, --verbose        Sets log level to DEBUG

± echo $?
2
```