### PR TITLE
refactor: adopt new metadata format for compliance mapping

### DIFF
--- a/changes/unreleased/Changed-20221215-080749.yaml
+++ b/changes/unreleased/Changed-20221215-080749.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: adopt new metadata format for compliance mappings
+time: 2022-12-15T08:07:49.601283757Z

--- a/docs/policy_spec.md
+++ b/docs/policy_spec.md
@@ -195,7 +195,7 @@ to clarify the intent of each field.
 | `category`      | string | The category of the policy                                                                                       |
 | `labels`        | array  | An array of labels (value-less tags) associated with this policy.                                                |
 | `service_group` | string | The service group of the primary resource associated with this policy (e.g. "EBS", "EC2")                        |
-| `controls`      | object | A map of rule set ID to a map of versions to a list of control IDs                                               |
+| `controls`      | array  | An array of control IDs to map to a compliance control                                                           |
 | `severity`      | string | The severity of the issue identified by this policy                                                              |
 | `product`       | array  | An array of the products this policy supports                                                                    |
 

--- a/examples/metadata/rules/snyk_001/metadata.json
+++ b/examples/metadata/rules/snyk_001/metadata.json
@@ -31,17 +31,10 @@
       "Pet Peeves"
     ],
     "service_group": "S3",
-    "controls": {
-      "CIS-AWS": {
-        "v1.3.0": [
-          "5.1",
-          "5.2"
-        ],
-        "v1.4.0": [
-          "6.7"
-        ]
-      }
-    },
+    "controls": [
+      "CIS-AWS_v1.3.0_5.1",
+      "CIS-AWS_v1.3.0_5.2"
+    ],
     "severity": "Critical"
   }
 }

--- a/pkg/models/model_rule_results.go
+++ b/pkg/models/model_rule_results.go
@@ -27,7 +27,7 @@ type RuleResults struct {
 	// The service group of the primary resource associated with this policy (e.g. \"EBS\", \"EC2\")
 	ServiceGroup string `json:"service_group,omitempty"`
 	// A map of rule set ID to a map of versions to a list of control IDs
-	Controls map[string]map[string][]string `json:"controls,omitempty"`
+	Controls []string `json:"controls,omitempty"`
 	// A list of resource types that the rule uses.
 	ResourceTypes []string     `json:"resource_types,omitempty"`
 	Results       []RuleResult `json:"results"`

--- a/pkg/policy/base.go
+++ b/pkg/policy/base.go
@@ -139,7 +139,7 @@ type Metadata struct {
 	Category     string                         `json:"category"`
 	Labels       []string                       `json:"labels,omitempty"`
 	ServiceGroup string                         `json:"service_group"`
-	Controls     map[string]map[string][]string `json:"controls"`
+	Controls     []string                       `json:"controls"`
 	Severity     string                         `json:"severity"`
 	Product      []string                       `json:"product"`
 }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -204,14 +204,10 @@ components:
           description: The service group of the primary resource associated with this policy (e.g. "EBS", "EC2")
           type: string
         controls:
-          type: object
+          type: array
           description: A map of rule set ID to a map of versions to a list of control IDs
-          additionalProperties:
-            type: object
-            additionalProperties:
-              type: array
-              items:
-                type: string
+          items:
+            type: string
         resource_types:
           type: array
           description: A list of resource types that the rule uses.

--- a/test/examples_test.json
+++ b/test/examples_test.json
@@ -364,17 +364,10 @@
               "Pet Peeves"
             ],
             "service_group": "S3",
-            "controls": {
-              "CIS-AWS": {
-                "v1.3.0": [
-                  "5.1",
-                  "5.2"
-                ],
-                "v1.4.0": [
-                  "6.7"
-                ]
-              }
-            },
+            "controls": [
+              "CIS-AWS_v1.3.0_5.1",
+              "CIS-AWS_v1.3.0_5.2"
+            ],
             "resource_types": [
               "aws_s3_bucket"
             ],


### PR DESCRIPTION
As part of the compliance mappings efforts of Chris, we're introducing a new metadata format for the `controls` attribute.

Related changes can be found in the policy library repository.