### PR TITLE
fix: too many open files

### DIFF
--- a/changes/unreleased/Fixed-20230105-232252.yaml
+++ b/changes/unreleased/Fixed-20230105-232252.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: too many open files when reading large amount of rego files
+time: 2023-01-05T23:22:52.673034294+01:00

--- a/pkg/data/provider.go
+++ b/pkg/data/provider.go
@@ -84,12 +84,14 @@ func LocalProvider(root string) Provider {
 	}
 }
 
-func TarGzProvider(reader io.Reader) Provider {
+func TarGzProvider(reader io.ReadCloser) Provider {
 	return func(ctx context.Context, consumer Consumer) error {
+		defer reader.Close()
 		gzf, err := gzip.NewReader(reader)
 		if err != nil {
 			return err
 		}
+		defer gzf.Close()
 
 		tarReader := tar.NewReader(gzf)
 		for true {

--- a/pkg/data/provider.go
+++ b/pkg/data/provider.go
@@ -44,6 +44,7 @@ func FSProvider(fsys fs.FS, basePath string) Provider {
 				if err != nil {
 					return err
 				}
+				defer reader.Close()
 				if err := parser(ctx, basePath, path, reader, consumer); err != nil {
 					return err
 				}
@@ -72,6 +73,7 @@ func LocalProvider(root string) Provider {
 					if err != nil {
 						return err
 					}
+					defer reader.Close()
 					if err := parser(ctx, root, path, reader, consumer); err != nil {
 						return err
 					}


### PR DESCRIPTION
On Linux, with a soft nofile limit of 1024, I was consistently getting errors for repositories with many rego files.  This fixes that by closing the file handles as soon as we've parsed the files.