### PR TITLE
feat: add -c to repl command (CLOUD-1088)

### DIFF
--- a/changes/unreleased/Added-20230110-120307.yaml
+++ b/changes/unreleased/Added-20230110-120307.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'repl: add `-c command` flag for use in scripts'
+time: 2023-01-10T12:03:07.48219688+01:00

--- a/changes/unreleased/Added-20230110-120307.yaml
+++ b/changes/unreleased/Added-20230110-120307.yaml
@@ -1,3 +1,3 @@
 kind: Added
-body: 'repl: add `-c command` flag for use in scripts'
+body: 'add `eval` command for use in scripts'
 time: 2023-01-10T12:03:07.48219688+01:00

--- a/cmd/fixture.go
+++ b/cmd/fixture.go
@@ -22,9 +22,12 @@ import (
 	"strings"
 
 	"github.com/open-policy-agent/opa/format"
-	"github.com/snyk/policy-engine/pkg/input"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+
+	"github.com/snyk/policy-engine/pkg/input"
+	"github.com/snyk/policy-engine/pkg/logging"
+	"github.com/snyk/policy-engine/pkg/models"
 )
 
 var (
@@ -40,21 +43,9 @@ var fixtureCmd = &cobra.Command{
 		if len(args) != 1 {
 			return fmt.Errorf("Expected a single input but got %d", len(args))
 		}
-		detector, err := input.DetectorByInputTypes(input.Types{input.Auto})
+		inputState, err := loadSingleInput(ctx, logger, args[0])
 		if err != nil {
 			return err
-		}
-		i, err := input.NewDetectable(afero.OsFs{}, args[0])
-		if err != nil {
-			return err
-		}
-		loader := input.NewLoader(detector)
-		loaded, err := loader.Load(i, input.DetectOptions{})
-		if err != nil {
-			return err
-		}
-		if !loaded {
-			return fmt.Errorf("Unable to find recognized input in %s", args[0])
 		}
 		packageName := cmdFixturePackage
 		if packageName == "" {
@@ -70,20 +61,7 @@ var fixtureCmd = &cobra.Command{
 			packageName = strings.Join(parts, ".")
 		}
 
-		// Log non-fatal errors if we're debugging.
-		if *rootCmdVerbose {
-			for path, errs := range loader.Errors() {
-				for _, err := range errs {
-					logger.Warn(ctx, fmt.Sprintf("%s: %s", path, err))
-				}
-			}
-		}
-
-		states := loader.ToStates()
-		if len(states) != 1 {
-			return fmt.Errorf("Expected a single state but got %d", len(states))
-		}
-		bytes, err := json.MarshalIndent(states[0], "", "  ")
+		bytes, err := json.MarshalIndent(inputState, "", "  ")
 		if err != nil {
 			return err
 		}
@@ -98,6 +76,40 @@ mock_input = %s`, packageName, string(bytes)))
 		fmt.Printf("%s", string(bytes))
 		return nil
 	},
+}
+
+func loadSingleInput(ctx context.Context, logger logging.Logger, path string) (*models.State, error) {
+	detector, err := input.DetectorByInputTypes(input.Types{input.Auto})
+	if err != nil {
+		return nil, err
+	}
+	i, err := input.NewDetectable(afero.OsFs{}, path)
+	if err != nil {
+		return nil, err
+	}
+	loader := input.NewLoader(detector)
+	loaded, err := loader.Load(i, input.DetectOptions{})
+
+	// Log non-fatal errors if we're debugging.
+	if *rootCmdVerbose {
+		for path, errs := range loader.Errors() {
+			for _, err := range errs {
+				logger.Warn(ctx, fmt.Sprintf("%s: %s", path, err))
+			}
+		}
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if !loaded {
+		return nil, fmt.Errorf("Unable to find recognized input in %s", path)
+	}
+	states := loader.ToStates()
+	if len(states) != 1 {
+		return nil, fmt.Errorf("Expected a single state but got %d", len(states))
+	}
+	return &states[0], nil
 }
 
 func init() {

--- a/cmd/metadata.go
+++ b/cmd/metadata.go
@@ -35,17 +35,7 @@ var metadataCmd = &cobra.Command{
 		providers := []data.Provider{
 			data.PureRegoLibProvider(),
 		}
-		for _, path := range rootCmdRegoPaths {
-			if isTgz(path) {
-				f, err := os.Open(path)
-				if err != nil {
-					return err
-				}
-				providers = append(providers, data.TarGzProvider(f))
-			} else {
-				providers = append(providers, data.LocalProvider(path))
-			}
-		}
+		providers = append(providers, rootCmdRegoProviders()...)
 		ctx := context.Background()
 		eng, err := engine.NewEngine(ctx, &engine.EngineOptions{
 			Providers: providers,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -50,20 +50,8 @@ var runCmd = &cobra.Command{
 		for _, k := range runCmdRules {
 			selectedRules[k] = true
 		}
-		providers := []data.Provider{
-			data.PureRegoLibProvider(),
-		}
-		for _, path := range rootCmdRegoPaths {
-			if isTgz(path) {
-				f, err := os.Open(path)
-				if err != nil {
-					return err
-				}
-				providers = append(providers, data.TarGzProvider(f))
-			} else {
-				providers = append(providers, data.LocalProvider(path))
-			}
-		}
+		providers := []data.Provider{data.PureRegoLibProvider()}
+		providers = append(providers, rootCmdRegoProviders()...)
 		detector, err := input.DetectorByInputTypes(
 			input.Types{input.Auto},
 		)

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -47,9 +47,7 @@ var testCmd = &cobra.Command{
 			data.PureRegoBuiltinsProvider(),
 			data.PureRegoLibProvider(),
 		}
-		for _, path := range rootCmdRegoPaths {
-			providers = append(providers, data.LocalProvider(path))
-		}
+		providers = append(providers, rootCmdRegoProviders()...)
 
 		consumer := engine.NewPolicyConsumer()
 		for _, provider := range providers {


### PR DESCRIPTION
The `-i command` flag is useful, but the REPL continues to run which makes it unfit for use in scripts.  We can add a `-c command` to get something closer to `opa eval`.