### PR TITLE
feat: export more resource info from hcl_interpreter

### DIFF
--- a/changes/unreleased/Changed-20230111-120801.yaml
+++ b/changes/unreleased/Changed-20230111-120801.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: return more resource metadata from the hcl_interpreter library
+time: 2023-01-11T12:08:01.186352176+01:00

--- a/pkg/hcl_interpreter/hcl_interpreter.go
+++ b/pkg/hcl_interpreter/hcl_interpreter.go
@@ -322,8 +322,13 @@ func (v *Evaluation) evaluate() error {
 	return nil
 }
 
-func (v *Evaluation) Resources() []models.ResourceState {
-	resources := []models.ResourceState{}
+type Resource struct {
+	Meta  *ResourceMeta
+	Model models.ResourceState
+}
+
+func (v *Evaluation) Resources() []Resource {
+	resources := []Resource{}
 
 	for resourceKey, resource := range v.Analysis.Resources {
 		resourceName, err := StringToFullName(resourceKey)
@@ -406,11 +411,14 @@ func (v *Evaluation) Resources() []models.ResourceState {
 		attrs = schemas.ApplyObject(attrs, tfschemas.GetSchema(resourceType))
 
 		// TODO: Support tags again: PopulateTags(input[resourceKey])
-		resources = append(resources, models.ResourceState{
-			Id:           resourceKey,
-			ResourceType: resourceType,
-			Attributes:   attrs,
-			Meta:         meta,
+		resources = append(resources, Resource{
+			Meta: resource,
+			Model: models.ResourceState{
+				Id:           resourceKey,
+				ResourceType: resourceType,
+				Attributes:   attrs,
+				Meta:         meta,
+			},
 		})
 	}
 

--- a/pkg/input/tf.go
+++ b/pkg/input/tf.go
@@ -81,7 +81,11 @@ func newHclConfiguration(moduleTree *hcl_interpreter.ModuleTree) (*HclConfigurat
 		return nil, fmt.Errorf("%w: %v", FailedToParseInput, err)
 	}
 
-	resources := evaluation.Resources()
+	resources := []models.ResourceState{}
+	for _, resource := range evaluation.Resources() {
+		resources = append(resources, resource.Model)
+	}
+
 	namespace := moduleTree.FilePath()
 	for i := range resources {
 		resources[i].Namespace = namespace

--- a/pkg/input/tf.go
+++ b/pkg/input/tf.go
@@ -81,9 +81,10 @@ func newHclConfiguration(moduleTree *hcl_interpreter.ModuleTree) (*HclConfigurat
 		return nil, fmt.Errorf("%w: %v", FailedToParseInput, err)
 	}
 
-	resources := []models.ResourceState{}
-	for _, resource := range evaluation.Resources() {
-		resources = append(resources, resource.Model)
+	evaluationResources := evaluation.Resources()
+	resources := make([]models.ResourceState, len(evaluationResources))
+	for i := range evaluationResources {
+		resources[i] = evaluationResources[i].Model
 	}
 
 	namespace := moduleTree.FilePath()


### PR DESCRIPTION
I was working on using the hcl_interpreter library in Regula, and found it hard to access certain fields that we're currently populating there (`_filepath`, `_provider`).  This change exports a little more resource information for consumers of hcl_interpreter.