### PR TITLE
fix: CLOUD-1168 remove input for multi-resource policies

### DIFF
--- a/changes/unreleased/Fixed-20230203-133834.yaml
+++ b/changes/unreleased/Fixed-20230203-133834.yaml
@@ -1,0 +1,4 @@
+kind: Fixed
+body: remove input for multi-resource policies to address extreme memory usage for
+  large inputs
+time: 2023-02-03T13:38:34.906307-05:00

--- a/pkg/policy/base.go
+++ b/pkg/policy/base.go
@@ -60,7 +60,6 @@ var SupportedInputTypes = input.Types{
 type EvalOptions struct {
 	RegoOptions       []func(*rego.Rego)
 	Input             *models.State
-	InputValue        ast.Value
 	Logger            logging.Logger
 	ResourcesResolver ResourcesResolver
 }

--- a/pkg/policy/multi.go
+++ b/pkg/policy/multi.go
@@ -66,7 +66,6 @@ func (p *MultiResourcePolicy) Eval(
 	opts := append(
 		options.RegoOptions,
 		rego.Query(p.judgementRule.query()),
-		rego.ParsedInput(options.InputValue),
 	)
 	builtins := NewBuiltins(options.Input, options.ResourcesResolver)
 	opts = append(opts, builtins.Rego()...)


### PR DESCRIPTION
This PR makes it so that we no-longer set `input` for multi-resource policies. The conversion between our structs and OPA's representation is too costly for large inputs. Instead, policy authors should interact with resources from the input via the `snyk.resources()` function, which does not rely on `input` being set.