### PR TITLE
chore: improve release process (CLOUD-1178)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check changelog entry
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check changelog entry
       run: |
         REMOTE=$(git remote | head)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,16 +10,16 @@ jobs:
     environment: release
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: '1.18'
     - run: make install_tools
     - name: Extract tag name from git ref
       id: tag_name
-      run: echo ::set-output name=TAG_NAME::${GITHUB_REF/refs\/tags\//}
+      run: echo "TAG_NAME=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
     - name: Ensure changelog exists
       run: ls changes/${{ steps.tag_name.outputs.TAG_NAME }}.md
     - name: Run goreleaser

--- a/.github/workflows/release_candidate.yml
+++ b/.github/workflows/release_candidate.yml
@@ -1,0 +1,26 @@
+name: release_candidate
+
+on:
+  push:
+    branches:
+      - 'release/**'
+
+jobs:
+  release_candidate:
+    environment: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
+      - run: make install_tools
+      - name: Extract version name from git branch
+        id: version
+        run: echo "VERSION=v${GITHUB_REF#*release/}" >> $GITHUB_OUTPUT
+      - name: Ensure changelog exists
+        run: ls changes/${{ steps.version.outputs.VERSION }}.md
+      - name: Run goreleaser
+        run: goreleaser build --snapshot

--- a/.github/workflows/tag_release_version.yml
+++ b/.github/workflows/tag_release_version.yml
@@ -1,0 +1,28 @@
+name: tag_release_version
+
+on:
+  pull_request:
+    types:
+    - closed
+
+jobs:
+  tag_release_version:
+    if: github.event.pull_request.merged && startsWith(github.event.pull_request.head.ref, "release/")
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: main
+    - name: Extract version from branch name
+      id: version
+      run: |
+        BRANCH_NAME=${{ github.event.pull_request.head.ref }}
+        VERSION=v${BRANCH_NAME#release/}
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+    - name: Tag version
+      run: |
+        VERSION=${{ steps.version.outputs.VERSION }}
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+        git tag -a -F changes/$VERSION.md $VERSION
+        git push origin $VERSION

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,10 +10,10 @@ jobs:
       matrix:
         go: ["1.17", "1.18"]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
     - run: go install github.com/open-policy-agent/opa@v0.39.0

--- a/Makefile
+++ b/Makefile
@@ -59,19 +59,21 @@ install_tools:
 	go install github.com/goreleaser/goreleaser@v1.9.2
 	go install github.com/miniscruff/changie@v1.7.0
 
+PLAIN_VERSION := $(VERSION:v=)
+
 .PHONY: release
 release:
 	@echo "Testing if $(VERSION) is set..."
 	test $(VERSION)
 	changie batch $(VERSION)
 	changie merge
+	git checkout -b release/$(PLAIN_VERSION)
 	git add changes CHANGELOG.md
 	git diff --staged
 	@echo -n "Are you sure? [y/N] " && read ans && [ $${ans:-N} == y ]
 	git commit -m "Bump version to $(VERSION)"
-	git tag -a -F changes/$(VERSION).md $(VERSION)
-	git push origin main $(VERSION)
-
+	git push origin release/$(PLAIN_VERSION) $(VERSION)
+	@echo "Go to https://github.com/snyk/policy-engine/compare/release/$(VERSION)?expand=1"
 
 TERRAFORM_VERSION=1.0.10
 

--- a/changes/unreleased/Changed-20230208-123940.yaml
+++ b/changes/unreleased/Changed-20230208-123940.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: improve release process
+time: 2023-02-08T12:39:40.502192327+01:00


### PR DESCRIPTION
  * `release_candidate`: new workflow that runs on release branches and tries
    to do a `goreleaser build.
  * `tag_release_version`: new workflow that runs when a `release/*` branch is
    merged and tags the version.
  * Update `actions/checkout` action to `v3`
  * Update `actions/setup-go` action to v3
  * Update use of deprecated `::set-output` to `$GITHUB_OUTPUT`