### PR TITLE
fix: CLOUD-1168 use empty input to not break some existing policies

### DIFF
--- a/changes/unreleased/Fixed-20230208-164224.yaml
+++ b/changes/unreleased/Fixed-20230208-164224.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: broken multi-resource policies that reference input for testing purposes
+time: 2023-02-08T16:42:24.870397-05:00

--- a/pkg/policy/multi.go
+++ b/pkg/policy/multi.go
@@ -66,6 +66,9 @@ func (p *MultiResourcePolicy) Eval(
 	opts := append(
 		options.RegoOptions,
 		rego.Query(p.judgementRule.query()),
+		rego.Input(map[string]interface{}{
+			"resources": map[string]interface{}{},
+		}),
 	)
 	builtins := NewBuiltins(options.Input, options.ResourcesResolver)
 	opts = append(opts, builtins.Rego()...)


### PR DESCRIPTION
There are some existing policies that use a pattern that redefines `input`, like:

```open-policy-engine
deny = ret {
        ret = some_lib.deny with input as {
                "resources": input.resources,
                "some_param": "foo",
        }
}
```

The `"resources": input.resources` is necessary in order to test these policies, because `policy-engine test` uses a pure rego implementation of `snyk.resources` that reads from `input`.

The `resources` entries are otherwise unused, so this PR sets a fake input document in multi-resource policies so that policies written like the above will continue to work.