### PR TITLE
chore: update license and copyright blocks

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -187,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2022 Snyk Ltd.
+   Copyright [yyyy] [name of copyright owner]
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -200,3 +199,16 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+
+------------------------------------------------------------------------------------
+This product bundles various third-party components under other open source licenses.
+This section summarizes those components and their licenses. See the LICENSE file
+in each package for text of these licenses.
+
+
+Mozilla Public License 2.0
+--------------------------------------
+
+pkg/hcl_interpreter/funcs
+pkg/internal/terraform

--- a/changes/unreleased/Updated-20230213-130641.yaml
+++ b/changes/unreleased/Updated-20230213-130641.yaml
@@ -1,0 +1,3 @@
+kind: Updated
+body: license and copyright blocks
+time: 2023-02-13T13:06:41.996059-05:00

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Snyk Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import "github.com/spf13/cobra"

--- a/cmd/bundle_create.go
+++ b/cmd/bundle_create.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Snyk Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/bundle_show.go
+++ b/cmd/bundle_show.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Snyk Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/bundle_validate.go
+++ b/cmd/bundle_validate.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Snyk Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/eval.go
+++ b/cmd/eval.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/fixture.go
+++ b/cmd/fixture.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/metadata.go
+++ b/cmd/metadata.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/repl.go
+++ b/cmd/repl.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/bundle/base/bundle.go
+++ b/pkg/bundle/base/bundle.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Snyk Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package base
 
 import (

--- a/pkg/bundle/base/io.go
+++ b/pkg/bundle/base/io.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Snyk Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package base
 
 import (

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Snyk Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package bundle
 
 import (

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Snyk Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package bundle_test
 
 import (

--- a/pkg/bundle/factory.go
+++ b/pkg/bundle/factory.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Snyk Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package bundle
 
 import (

--- a/pkg/bundle/io.go
+++ b/pkg/bundle/io.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Snyk Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package bundle
 
 import (

--- a/pkg/bundle/v1/bundle.go
+++ b/pkg/bundle/v1/bundle.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Snyk Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package v1
 
 import (

--- a/pkg/bundle/v1/test_inputs/complete/lib/utils.rego
+++ b/pkg/bundle/v1/test_inputs/complete/lib/utils.rego
@@ -1,3 +1,17 @@
+# Copyright 2023 Snyk Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 package lib.utils
 
 bucket_name_contains(bucket, query) {

--- a/pkg/bundle/v1/test_inputs/complete/rules/EXAMPLE_01/metadata.yaml
+++ b/pkg/bundle/v1/test_inputs/complete/rules/EXAMPLE_01/metadata.yaml
@@ -1,3 +1,17 @@
+# Copyright 2023 Snyk Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 metadata:
   id: EXAMPLE_01
   title: Bucket name contains the word 'bucket'

--- a/pkg/bundle/v1/test_inputs/complete/rules/EXAMPLE_01/terraform.rego
+++ b/pkg/bundle/v1/test_inputs/complete/rules/EXAMPLE_01/terraform.rego
@@ -1,3 +1,17 @@
+# Copyright 2023 Snyk Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 package rules.EXAMPLE_01.terraform
 
 import data.lib.utils

--- a/pkg/bundle/v1/test_inputs/complete/rules/EXAMPLE_02/terraform.rego
+++ b/pkg/bundle/v1/test_inputs/complete/rules/EXAMPLE_02/terraform.rego
@@ -1,3 +1,17 @@
+# Copyright 2023 Snyk Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 package rules.EXAMPLE_02.terraform
 
 import data.snyk

--- a/pkg/bundle/v1/test_inputs/minimal/rules/some_rule.rego
+++ b/pkg/bundle/v1/test_inputs/minimal/rules/some_rule.rego
@@ -1,3 +1,17 @@
+# Copyright 2023 Snyk Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 package rules.playlist_guardrails
 
 import data.snyk

--- a/pkg/data/base.go
+++ b/pkg/data/base.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/data/extensions.go
+++ b/pkg/data/extensions.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/data/filepath.go
+++ b/pkg/data/filepath.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/data/provider.go
+++ b/pkg/data/provider.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/engine/consumer.go
+++ b/pkg/engine/consumer.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/engine/errors.go
+++ b/pkg/engine/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/engine/instrumentation.go
+++ b/pkg/engine/instrumentation.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Snyk Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package engine
 
 import (

--- a/pkg/engine/policyset.go
+++ b/pkg/engine/policyset.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Snyk Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package engine
 
 import (

--- a/pkg/hcl_interpreter/data.go
+++ b/pkg/hcl_interpreter/data.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/hcl_interpreter/funcs/crypto.go
+++ b/pkg/hcl_interpreter/funcs/crypto.go
@@ -1,17 +1,3 @@
-// Copyright 2022 Snyk Ltd
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package funcs
 
 import (

--- a/pkg/hcl_interpreter/funcs/filesystem.go
+++ b/pkg/hcl_interpreter/funcs/filesystem.go
@@ -1,17 +1,3 @@
-// Copyright 2022 Snyk Ltd
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package funcs
 
 import (

--- a/pkg/hcl_interpreter/funcs/filesystem_test.go
+++ b/pkg/hcl_interpreter/funcs/filesystem_test.go
@@ -1,17 +1,3 @@
-// Copyright 2022 Snyk Ltd
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package funcs
 
 import (

--- a/pkg/hcl_interpreter/funcs/override.go
+++ b/pkg/hcl_interpreter/funcs/override.go
@@ -1,17 +1,3 @@
-// Copyright 2022 Snyk Ltd
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 package funcs
 
 import (

--- a/pkg/hcl_interpreter/hcl_interpreter.go
+++ b/pkg/hcl_interpreter/hcl_interpreter.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/hcl_interpreter/moduleregister.go
+++ b/pkg/hcl_interpreter/moduleregister.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/hcl_interpreter/moduletree.go
+++ b/pkg/hcl_interpreter/moduletree.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/hcl_interpreter/moduletree_test.go
+++ b/pkg/hcl_interpreter/moduletree_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/hcl_interpreter/names.go
+++ b/pkg/hcl_interpreter/names.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/hcl_interpreter/names_test.go
+++ b/pkg/hcl_interpreter/names_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/hcl_interpreter/phantom_attrs.go
+++ b/pkg/hcl_interpreter/phantom_attrs.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/hcl_interpreter/source_locations.go
+++ b/pkg/hcl_interpreter/source_locations.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/hcl_interpreter/tags.go
+++ b/pkg/hcl_interpreter/tags.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/hcl_interpreter/term.go
+++ b/pkg/hcl_interpreter/term.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/hcl_interpreter/valtree.go
+++ b/pkg/hcl_interpreter/valtree.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/hcl_interpreter/value.go
+++ b/pkg/hcl_interpreter/value.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/hcl_interpreter/varfiles.go
+++ b/pkg/hcl_interpreter/varfiles.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/input/adapter.go
+++ b/pkg/input/adapter.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/input/arm.go
+++ b/pkg/input/arm.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 // Copyright 2021 Fugue, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/input/cfn.go
+++ b/pkg/input/cfn.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 // Copyright 2021 Fugue, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/input/cfn_test.go
+++ b/pkg/input/cfn_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 // Copyright 2021 Fugue, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/input/detector.go
+++ b/pkg/input/detector.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 // Copyright 2021 Fugue, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/input/detector_by_type.go
+++ b/pkg/input/detector_by_type.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 // Copyright 2021 Fugue, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/input/errors.go
+++ b/pkg/input/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/input/golden_location_test.go
+++ b/pkg/input/golden_location_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test.go
+++ b/pkg/input/golden_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 // Copyright 2021 Fugue, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/input/golden_test/cfn/example-01/main.yaml
+++ b/pkg/input/golden_test/cfn/example-01/main.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/cfn/example-02/main.yaml
+++ b/pkg/input/golden_test/cfn/example-02/main.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/cfn/example-03/main.yaml
+++ b/pkg/input/golden_test/cfn/example-03/main.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/cfn/intrinsics/main.yaml
+++ b/pkg/input/golden_test/cfn/intrinsics/main.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 # Copyright 2020-2021 Fugue, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/input/golden_test/cfn/no-props/template.yaml
+++ b/pkg/input/golden_test/cfn/no-props/template.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/cfn/params-01/main.yml
+++ b/pkg/input/golden_test/cfn/params-01/main.yml
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/cfn/schemas-01/template.yaml
+++ b/pkg/input/golden_test/cfn/schemas-01/template.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/k8s/docs/manifest.yaml
+++ b/pkg/input/golden_test/k8s/docs/manifest.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/k8s/example-01/main.yaml
+++ b/pkg/input/golden_test/k8s/example-01/main.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/k8s/namespaces/manifest.yaml
+++ b/pkg/input/golden_test/k8s/namespaces/manifest.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/count-local/main.tf
+++ b/pkg/input/golden_test/tf/count-local/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/count-ref/main.tf
+++ b/pkg/input/golden_test/tf/count-ref/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/count-simple/main.tf
+++ b/pkg/input/golden_test/tf/count-simple/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/count-var/main.tf
+++ b/pkg/input/golden_test/tf/count-var/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/data-resources/main.tf
+++ b/pkg/input/golden_test/tf/data-resources/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/empty-block/main.tf
+++ b/pkg/input/golden_test/tf/empty-block/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/empty-resource/test.tf
+++ b/pkg/input/golden_test/tf/empty-resource/test.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/file/main.tf
+++ b/pkg/input/golden_test/tf/file/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/for-each/main.tf
+++ b/pkg/input/golden_test/tf/for-each/main.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Snyk Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 resource "azurerm_resource_group" "rg" {
   for_each = {
     a_group = "eastus"

--- a/pkg/input/golden_test/tf/kubernetes-01/main.tf
+++ b/pkg/input/golden_test/tf/kubernetes-01/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/nested-vars-rm5823/main.tf
+++ b/pkg/input/golden_test/tf/nested-vars-rm5823/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/null-count/main.tf
+++ b/pkg/input/golden_test/tf/null-count/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/output-nil-expr/main.tf
+++ b/pkg/input/golden_test/tf/output-nil-expr/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/provider-version/main.tf
+++ b/pkg/input/golden_test/tf/provider-version/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/regula-issue-245/test.tf
+++ b/pkg/input/golden_test/tf/regula-issue-245/test.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/regula-issue-305/main.tf
+++ b/pkg/input/golden_test/tf/regula-issue-305/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/regula-issue-389/main.tf
+++ b/pkg/input/golden_test/tf/regula-issue-389/main.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Snyk Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # See <https://github.com/fugue/regula/issues/389>
 variable "team" {
   type = string

--- a/pkg/input/golden_test/tf/repeated-blocks/main.tf
+++ b/pkg/input/golden_test/tf/repeated-blocks/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/sensitive-tfcscm-174/main.tf
+++ b/pkg/input/golden_test/tf/sensitive-tfcscm-174/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/sensitive/main.tf
+++ b/pkg/input/golden_test/tf/sensitive/main.tf
@@ -1,3 +1,17 @@
+# Copyright 2023 Snyk Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 provider "aws" {
     region = "us-east-1"
 }

--- a/pkg/input/golden_test/tf/tags/main.tf
+++ b/pkg/input/golden_test/tf/tags/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 # Copyright 2020-2021 Fugue, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/input/golden_test/tf/template-in-jsonencode/main.tf
+++ b/pkg/input/golden_test/tf/template-in-jsonencode/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/ternary-mismatch/main.tf
+++ b/pkg/input/golden_test/tf/ternary-mismatch/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/tfvars-01/main.tf
+++ b/pkg/input/golden_test/tf/tfvars-01/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/tfvars-02/main.tf
+++ b/pkg/input/golden_test/tf/tfvars-02/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/golden_test/tf/vars/main.tf
+++ b/pkg/input/golden_test/tf/vars/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/k8s.go
+++ b/pkg/input/k8s.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 // Copyright 2021 Fugue, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/input/loader.go
+++ b/pkg/input/loader.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/input/loader_test.go
+++ b/pkg/input/loader_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/input/multi.go
+++ b/pkg/input/multi.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 // Copyright 2021 Fugue, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/input/schemas/cfn/cfn.go
+++ b/pkg/input/schemas/cfn/cfn.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/input/schemas/cfn/cfn_test.go
+++ b/pkg/input/schemas/cfn/cfn_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/input/schemas/cfn/parse.go
+++ b/pkg/input/schemas/cfn/parse.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/input/schemas/schemas.go
+++ b/pkg/input/schemas/schemas.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/input/schemas/tf/generate/extract.go
+++ b/pkg/input/schemas/tf/generate/extract.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Snyk Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/pkg/input/schemas/tf/generate/main_aws.go
+++ b/pkg/input/schemas/tf/generate/main_aws.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Snyk Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/pkg/input/schemas/tf/generate/main_azurerm.go
+++ b/pkg/input/schemas/tf/generate/main_azurerm.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Snyk Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/pkg/input/schemas/tf/generate/main_google.go
+++ b/pkg/input/schemas/tf/generate/main_google.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Snyk Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/pkg/input/schemas/tf/tf.go
+++ b/pkg/input/schemas/tf/tf.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/input/schemas/tf/tf_test.go
+++ b/pkg/input/schemas/tf/tf_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/input/source_info.go
+++ b/pkg/input/source_info.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 // Copyright 2021 Fugue, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/input/test_inputs/data/cfn.yaml
+++ b/pkg/input/test_inputs/data/cfn.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 # Copyright 2020-2021 Fugue, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/input/test_inputs/data/cfn_resources.yaml
+++ b/pkg/input/test_inputs/data/cfn_resources.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 # Copyright 2020-2021 Fugue, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/input/test_inputs/data/comment.yaml
+++ b/pkg/input/test_inputs/data/comment.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/input/test_inputs/test_inputs.go
+++ b/pkg/input/test_inputs/test_inputs.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 // Copyright 2021 Fugue, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/input/tf.go
+++ b/pkg/input/tf.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 // Copyright 2021 Fugue, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/input/tfplan.go
+++ b/pkg/input/tfplan.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 // Copyright 2021 Fugue, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/input/tfplan_test.go
+++ b/pkg/input/tfplan_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 // Copyright 2021 Fugue, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/input/tfstate.go
+++ b/pkg/input/tfstate.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 // Copyright 2021 Fugue, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/input/types.go
+++ b/pkg/input/types.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/input/types_test.go
+++ b/pkg/input/types_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/interfacetricks/copy.go
+++ b/pkg/interfacetricks/copy.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/interfacetricks/equal.go
+++ b/pkg/interfacetricks/equal.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/interfacetricks/equal_test.go
+++ b/pkg/interfacetricks/equal_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/interfacetricks/intersect.go
+++ b/pkg/interfacetricks/intersect.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/interfacetricks/merge.go
+++ b/pkg/interfacetricks/merge.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/interfacetricks/walker.go
+++ b/pkg/interfacetricks/walker.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/logging/fields.go
+++ b/pkg/logging/fields.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/metrics/names.go
+++ b/pkg/metrics/names.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/api.go
+++ b/pkg/policy/api.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/base.go
+++ b/pkg/policy/base.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/base_test.go
+++ b/pkg/policy/base_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/errors.go
+++ b/pkg/policy/errors.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/factory.go
+++ b/pkg/policy/factory.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/fugue.go
+++ b/pkg/policy/fugue.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/inferattributes/pathset.go
+++ b/pkg/policy/inferattributes/pathset.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/inferattributes/pathset_test.go
+++ b/pkg/policy/inferattributes/pathset_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/inferattributes/resource.go
+++ b/pkg/policy/inferattributes/resource.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/inferattributes/tracer.go
+++ b/pkg/policy/inferattributes/tracer.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/input_resolver.go
+++ b/pkg/policy/input_resolver.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/legacyiac.go
+++ b/pkg/policy/legacyiac.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/legacyiac/arm.go
+++ b/pkg/policy/legacyiac/arm.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/legacyiac/arm_test.go
+++ b/pkg/policy/legacyiac/arm_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/legacyiac/cfn.go
+++ b/pkg/policy/legacyiac/cfn.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/legacyiac/cfn_test.go
+++ b/pkg/policy/legacyiac/cfn_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/legacyiac/input.go
+++ b/pkg/policy/legacyiac/input.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/legacyiac/input_test.go
+++ b/pkg/policy/legacyiac/input_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/legacyiac/k8s.go
+++ b/pkg/policy/legacyiac/k8s.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/legacyiac/k8s_test.go
+++ b/pkg/policy/legacyiac/k8s_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/legacyiac/tf.go
+++ b/pkg/policy/legacyiac/tf.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/legacyiac/tf_test.go
+++ b/pkg/policy/legacyiac/tf_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/legacyiac_test.go
+++ b/pkg/policy/legacyiac_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/multi.go
+++ b/pkg/policy/multi.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/query.go
+++ b/pkg/policy/query.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/query_test.go
+++ b/pkg/policy/query_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/regoapi/fugue.rego
+++ b/pkg/policy/regoapi/fugue.rego
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/policy/regoapi/snyk.rego
+++ b/pkg/policy/regoapi/snyk.rego
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/policy/ruleresultbuilder.go
+++ b/pkg/policy/ruleresultbuilder.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/single.go
+++ b/pkg/policy/single.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/util.go
+++ b/pkg/policy/util.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/policy/util_test.go
+++ b/pkg/policy/util_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/postprocess/custom_severities.go
+++ b/pkg/postprocess/custom_severities.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/postprocess/custom_severities_test.go
+++ b/pkg/postprocess/custom_severities_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Snyk Ltd
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package postprocess
 
 import (

--- a/pkg/postprocess/resource_filter.go
+++ b/pkg/postprocess/resource_filter.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/postprocess/resource_filter_test.go
+++ b/pkg/postprocess/resource_filter_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/postprocess/source_locs.go
+++ b/pkg/postprocess/source_locs.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/postprocess/source_locs_test.go
+++ b/pkg/postprocess/source_locs_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/postprocess/source_locs_test/template.yaml
+++ b/pkg/postprocess/source_locs_test/template.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/snapshot_testing/builtin.go
+++ b/pkg/snapshot_testing/builtin.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/topsort/topsort.go
+++ b/pkg/topsort/topsort.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 // Copyright 2021 Fugue, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/topsort/topsort_test.go
+++ b/pkg/topsort/topsort_test.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 // Copyright 2021 Fugue, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rego/embed.go
+++ b/rego/embed.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Snyk Ltd
+// Copyright 2022-2023 Snyk Ltd
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rego/snyk.rego
+++ b/rego/snyk.rego
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rego/snyk/internal/relations.rego
+++ b/rego/snyk/internal/relations.rego
@@ -1,3 +1,17 @@
+# Copyright 2023 Snyk Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 package snyk.internal.relations
 
 make_resource_key(resource) = ret {

--- a/rego/snyk/internal/relations_example.rego
+++ b/rego/snyk/internal/relations_example.rego
@@ -1,3 +1,17 @@
+# Copyright 2023 Snyk Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 package relations
 
 import data.snyk

--- a/rego/snyk/internal/relations_test.rego
+++ b/rego/snyk/internal/relations_test.rego
@@ -1,3 +1,17 @@
+# Copyright 2023 Snyk Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 package snyk_test
 
 import data.snyk

--- a/rego/snyk/relations.rego
+++ b/rego/snyk/relations.rego
@@ -1,3 +1,17 @@
+# Copyright 2023 Snyk Ltd
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 package snyk
 
 import data.snyk.internal.relations

--- a/rego/snyk/terraform.rego
+++ b/rego/snyk/terraform.rego
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rego/snyk/terraform_test.rego
+++ b/rego/snyk/terraform_test.rego
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/rego/snyk_test.rego
+++ b/rego/snyk_test.rego
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/license.py
+++ b/scripts/license.py
@@ -78,6 +78,7 @@ def license_file(path, comment_prefix):
 
 
 ignores = [
+    "pkg/hcl_interpreter/funcs",
     "pkg/input/golden_test/tf/example-terraform-modules",
     "pkg/internal/terraform",
     "pkg/models",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Snyk Ltd
+# Copyright 2022-2023 Snyk Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
In this PR, I've:
* updated and re-run the license.py script
* removed some copyright blocks that got added by mistake
* updated our `LICENSE` to make it clear which parts of this project have a different license