### PR TITLE
fix: disable logging by default

### DIFF
--- a/changes/unreleased/Changed-20230217-114716.yaml
+++ b/changes/unreleased/Changed-20230217-114716.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: disabled logging by default
+time: 2023-02-17T11:47:16.13313-05:00

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -56,7 +56,7 @@ type EngineOptions struct {
 func NewEngine(ctx context.Context, options *EngineOptions) *Engine {
 	logger := options.Logger
 	if logger == nil {
-		logger = logging.DefaultLogger
+		logger = logging.NopLogger
 	}
 	m := options.Metrics
 	if m == nil {

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -21,10 +21,14 @@ import (
 	"github.com/rs/zerolog"
 )
 
-var DefaultLogger Logger = NewZeroLogger(zerolog.Logger{}.
+// StdErrLogger writes structured log messages to stderr
+var StdErrLogger Logger = NewZeroLogger(zerolog.Logger{}.
 	Level(zerolog.GlobalLevel()).
 	Output(os.Stderr).
 	With().Timestamp().Logger())
+
+// NopLogger does not write any messages. It can be used to disable logging.
+var NopLogger Logger = NewZeroLogger(zerolog.Nop())
 
 // Logger defines a simple interface for the pluggable logging in the policy engine
 type Logger interface {

--- a/pkg/policy/legacyiac.go
+++ b/pkg/policy/legacyiac.go
@@ -62,7 +62,7 @@ func (p *LegacyIaCPolicy) Eval(
 ) ([]models.RuleResults, error) {
 	logger := options.Logger
 	if logger == nil {
-		logger = logging.DefaultLogger
+		logger = logging.NopLogger
 	}
 	logger = logger.WithField(logging.POLICY_TYPE, "legacy_iac")
 	inputs, err := legacyIaCInput(options.Input)

--- a/pkg/policy/multi.go
+++ b/pkg/policy/multi.go
@@ -47,7 +47,7 @@ func (p *MultiResourcePolicy) Eval(
 ) ([]models.RuleResults, error) {
 	logger := options.Logger
 	if logger == nil {
-		logger = logging.DefaultLogger
+		logger = logging.NopLogger
 	}
 	logger = logger.WithField(logging.PACKAGE, p.Package()).
 		WithField(logging.POLICY_TYPE, "multi_resource").

--- a/pkg/policy/single.go
+++ b/pkg/policy/single.go
@@ -48,7 +48,7 @@ func (p *SingleResourcePolicy) Eval(
 ) ([]models.RuleResults, error) {
 	logger := options.Logger
 	if logger == nil {
-		logger = logging.DefaultLogger
+		logger = logging.NopLogger
 	}
 	logger = logger.WithField(logging.PACKAGE, p.Package()).
 		WithField(logging.POLICY_TYPE, "single_resource").


### PR DESCRIPTION
The default structured logging is turning out to be a nuisance. This PR adds a new `NopLogger` and changes the default behavior so that logging is disabled when a logger is not provided.