### PR TITLE
feat: add --log-level flag

### DIFF
--- a/changes/unreleased/Added-20230221-173748.yaml
+++ b/changes/unreleased/Added-20230221-173748.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: explicit --log-level flag
+time: 2023-02-21T17:37:48.104574454+01:00

--- a/cmd/fixture.go
+++ b/cmd/fixture.go
@@ -91,7 +91,7 @@ func loadSingleInput(ctx context.Context, logger logging.Logger, path string) (*
 	loaded, err := loader.Load(i, input.DetectOptions{})
 
 	// Log non-fatal errors if we're debugging.
-	if *rootCmdVerbose {
+	if rootCmdVerbosity.Debug() {
 		for path, errs := range loader.Errors() {
 			for _, err := range errs {
 				logger.Warn(ctx, fmt.Sprintf("%s: %s", path, err))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,7 @@ func check(errs ...error) {
 
 var (
 	rootCmdRegoPaths []string
-	rootCmdVerbose   *bool
+	rootCmdVerbosity Verbosity
 )
 
 var rootCmd = &cobra.Command{
@@ -56,12 +56,8 @@ func Execute() error {
 }
 
 func cmdLogger() logging.Logger {
-	logLevel := zerolog.InfoLevel
-	if *rootCmdVerbose {
-		logLevel = zerolog.DebugLevel
-	}
 	return logging.NewZeroLogger(zerolog.Logger{}.
-		Level(logLevel).
+		Level(rootCmdVerbosity.LogLevel()).
 		Output(zerolog.ConsoleWriter{Out: os.Stderr}).
 		With().Timestamp().Logger())
 }
@@ -140,8 +136,8 @@ func bundleReadersFromPaths(paths []string) ([]bundle.Reader, error) {
 }
 
 func init() {
-	rootCmdVerbose = rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Sets log level to DEBUG")
 	rootCmd.PersistentFlags().StringSliceVarP(&rootCmdRegoPaths, "data", "d", rootCmdRegoPaths, "Rego paths to load")
+	rootCmdVerbosity.InitFlags(rootCmd.PersistentFlags())
 	rootCmd.AddCommand(runCmd)
 	rootCmd.AddCommand(testCmd)
 	rootCmd.AddCommand(fixtureCmd)

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -85,7 +85,7 @@ var testCmd = &cobra.Command{
 				},
 			}).
 			SetCompiler(compiler).
-			EnableTracing(*rootCmdVerbose).
+			EnableTracing(rootCmdVerbosity.Debug()).
 			SetStore(store).
 			SetModules(consumer.Modules).
 			Filter(cmdTestFilter).
@@ -109,7 +109,7 @@ var testCmd = &cobra.Command{
 		reporter := tester.PrettyReporter{
 			Output:      os.Stdout,
 			FailureLine: true,
-			Verbose:     *rootCmdVerbose,
+			Verbose:     rootCmdVerbosity.Debug(),
 		}
 
 		if err := reporter.Report(dup); err != nil {

--- a/cmd/verbosity.go
+++ b/cmd/verbosity.go
@@ -1,0 +1,112 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/rs/zerolog"
+	"github.com/spf13/pflag"
+)
+
+// This is a helper structure that allows us to have the flags `--log-level` as
+// well as `-v`, which is equivalent to `--log-level debug`.
+type Verbosity struct {
+	verbose  bool
+	logLevel *zerolog.Level
+}
+
+// Print debug information.
+func (v *Verbosity) Debug() bool {
+	return v.verbose || (v.logLevel != nil && *v.logLevel == zerolog.DebugLevel)
+}
+
+// Get corresponding log level.
+func (v *Verbosity) LogLevel() zerolog.Level {
+	if v.logLevel != nil {
+		return *v.logLevel
+	}
+	return defaultLogLevel
+}
+
+// Initialize flags.
+func (v *Verbosity) InitFlags(flags *pflag.FlagSet) {
+	flags.VarP(&verbosityVerboseFlag{&rootCmdVerbosity}, "verbose", "v", "Sets log level to debug")
+	flags.Lookup("verbose").NoOptDefVal = "true"
+	flags.Var(&verbosityLogLevelFlag{&rootCmdVerbosity}, "log-level", "Sets log level")
+}
+
+var logLevels = []struct {
+	key   string
+	level zerolog.Level
+}{
+	{"debug", zerolog.DebugLevel},
+	{"info", zerolog.InfoLevel},
+	{"warn", zerolog.WarnLevel},
+	{"error", zerolog.ErrorLevel},
+}
+
+var defaultLogLevel = zerolog.InfoLevel
+
+// pflag.Value implementation for --log-level that does validation.
+type verbosityLogLevelFlag struct {
+	*Verbosity
+}
+
+func (v *verbosityLogLevelFlag) String() string {
+	level := v.LogLevel()
+	for _, logLevel := range logLevels {
+		if logLevel.level == level {
+			return logLevel.key
+		}
+	}
+	return "unknown"
+}
+
+func (v *verbosityLogLevelFlag) Set(key string) error {
+	for _, logLevel := range logLevels {
+		if logLevel.key == key {
+			v.logLevel = &logLevel.level
+
+			// Check consistency.
+			if logLevel.level != zerolog.DebugLevel && v.verbose {
+				return fmt.Errorf("expected debug when -v is set")
+			}
+			return nil
+		}
+	}
+	suggestions := []string{}
+	for _, logLevel := range logLevels {
+		suggestions = append(suggestions, logLevel.key)
+	}
+	return fmt.Errorf("expected one of: %s", strings.Join(suggestions, ", "))
+}
+
+func (v *verbosityLogLevelFlag) Type() string {
+	return "log-level"
+}
+
+// pflag.Value implementation for --verbose that does validation.
+type verbosityVerboseFlag struct {
+	*Verbosity
+}
+
+func (v *verbosityVerboseFlag) String() string {
+	if v.verbose {
+		return "true"
+	}
+	return "false"
+}
+
+func (v *verbosityVerboseFlag) Set(key string) error {
+	v.verbose = true
+
+	// Check consistency.
+	if v.logLevel != nil && *v.logLevel != zerolog.DebugLevel {
+		return fmt.Errorf("log-level must be set to debug")
+	}
+	return nil
+}
+
+func (v *verbosityVerboseFlag) Type() string {
+	return "bool"
+}

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/rs/zerolog v1.26.1
 	github.com/spf13/afero v1.8.2
 	github.com/spf13/cobra v1.6.1
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.8.0
 	github.com/zclconf/go-cty v1.12.1
 	github.com/zclconf/go-cty-yaml v1.0.2
@@ -78,7 +79,6 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sergi/go-diff v1.2.0 // indirect
-	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	github.com/ulikunitz/xz v0.5.8 // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12 // indirect


### PR DESCRIPTION
This adds a `--log-level` flag, that can be set to `debug`, `info`, `warn` or `error`.

The existing `--verbose` (`-v`) flag becomes equivalent to setting `--log-level debug`.

If both `--verbose` and `--log-level` are set, then we validate that `--log-level` is set to `debug` for consistency.