### PR TITLE
fix: update complete example bundle

### DIFF
--- a/changes/unreleased/Fixed-20230310-192411.yaml
+++ b/changes/unreleased/Fixed-20230310-192411.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: complete bundle example
+time: 2023-03-10T19:24:11.808601+01:00

--- a/pkg/bundle/v1/test_inputs/complete/lib/utils.rego
+++ b/pkg/bundle/v1/test_inputs/complete/lib/utils.rego
@@ -15,9 +15,11 @@
 package lib.utils
 
 bucket_name_contains(bucket, query) {
-	contains(bucket.bucket, "bucket")
+	is_string(bucket.bucket)
+	contains(bucket.bucket, query)
 }
 
 bucket_name_contains(bucket, query) {
-	contains(bucket.bucket_prefix, "bucket")
+	is_string(bucket.bucket_prefix)
+	contains(bucket.bucket_prefix, query)
 }


### PR DESCRIPTION
The library was failing on a null bucket_prefix in cloud scan