### PR TITLE
feat: add cloud resources options to repl

### DIFF
--- a/changes/unreleased/Added-20230317-100333.yaml
+++ b/changes/unreleased/Added-20230317-100333.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: cloud resources options to repl command
+time: 2023-03-17T10:03:33.748046-04:00


### PR DESCRIPTION
This PR adds the cloud resources options to the `repl` command.