### PR TITLE
feat: add alternate method to configure auth for cloudapi.Client

### DIFF
--- a/changes/unreleased/Added-20230422-161052.yaml
+++ b/changes/unreleased/Added-20230422-161052.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: alternate method to configure authorization for cloudapi.Client
+time: 2023-04-22T16:10:52.96592-04:00

--- a/pkg/input/cloudapi/resources.go
+++ b/pkg/input/cloudapi/resources.go
@@ -99,7 +99,7 @@ func (c *Client) resourcesPage(ctx context.Context, req *http.Request) (Collecti
 	req.Header.Set("Content-Type", "application/vnd.api+json")
 	req.Header.Set("Authorization", c.authorization)
 
-	res, err := c.httpClient.Do(req)
+	res, err := c.Do(req)
 	if err != nil {
 		return results, err
 	}


### PR DESCRIPTION
This PR adds an option to initialize `cloudapi.Client` with a pre-configured HTTP client. This is intended to function as an alternate authentication mechanism to providing a token.