### PR TITLE
fix: deny parsing for key-less rules (CLOUD-1433)

### DIFF
--- a/changes/unreleased/Fixed-20230426-132720.yaml
+++ b/changes/unreleased/Fixed-20230426-132720.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: deny parsing for key-less rules
+time: 2023-04-26T13:27:20.280236127+02:00

--- a/pkg/policy/base.go
+++ b/pkg/policy/base.go
@@ -109,11 +109,16 @@ func (i *ruleInfo) query() string {
 	if len(i.rules) < 1 {
 		return ""
 	}
-	q := i.rules[0].Path().String()
-	if i.hasKey() {
-		q += "[_]"
+	return i.rules[0].Path().String()
+}
+
+func (i *ruleInfo) queryElem() string {
+	q := i.query()
+	if q == "" {
+		return q
+	} else {
+		return q + "[_]"
 	}
-	return q
 }
 
 func (i *ruleInfo) hasKey() bool {

--- a/pkg/policy/factory.go
+++ b/pkg/policy/factory.go
@@ -46,14 +46,28 @@ func PolicyFactory(moduleSet ModuleSet) (Policy, error) {
 	} else {
 		switch base.judgementRule.name {
 		case "allow":
+			// NOTE(jaspervdj): hasKey() doesn't really work here, since it
+			// only deals with the _syntax_ of the code, and we want to talk
+			// about the _types_.
+			//
+			// For example, these are two ways to express the same `allow[info]`
+			// rule:
+			//
+			//     allow[info] { info = "message" }
+			//     allow = {"message"}
+			//
+			// However, `hasKey()` will classify them differently.  This is
+			// currently a known issue.
 			if base.judgementRule.hasKey() {
 				return &SingleResourcePolicy{
 					BasePolicy:       base,
+					Query:            base.judgementRule.queryElem(),
 					processorFactory: NewFugueAllowInfoProcessor,
 				}, nil
 			} else {
 				return &SingleResourcePolicy{
 					BasePolicy:       base,
+					Query:            base.judgementRule.query(),
 					processorFactory: NewFugueAllowBooleanProcessor,
 				}, nil
 			}
@@ -62,11 +76,13 @@ func PolicyFactory(moduleSet ModuleSet) (Policy, error) {
 			if base.judgementRule.hasKey() {
 				return &SingleResourcePolicy{
 					BasePolicy:       base,
+					Query:            base.judgementRule.queryElem(),
 					processorFactory: NewSingleDenyProcessor,
 				}, nil
 			} else {
 				return &SingleResourcePolicy{
 					BasePolicy:       base,
+					Query:            base.judgementRule.query(),
 					processorFactory: NewFugueDenyBooleanProcessor,
 				}, nil
 			}

--- a/pkg/policy/legacyiac.go
+++ b/pkg/policy/legacyiac.go
@@ -89,7 +89,7 @@ func (p *LegacyIaCPolicy) Eval(
 		strictBuiltinErrors := false
 		query := rego.Query{
 			Builtins:            builtins.Implementations(),
-			Query:               p.judgementRule.query(),
+			Query:               p.judgementRule.queryElem(),
 			Input:               inputValue,
 			StrictBuiltinErrors: &strictBuiltinErrors,
 		}

--- a/pkg/policy/multi.go
+++ b/pkg/policy/multi.go
@@ -77,7 +77,7 @@ func (p *MultiResourcePolicy) Eval(
 	tracer := inferattributes.NewTracer()
 
 	query := rego.Query{
-		Query:    p.judgementRule.query(),
+		Query:    p.judgementRule.queryElem(),
 		Builtins: builtins.Implementations(),
 		Tracers:  []topdown.QueryTracer{tracer},
 		Input: ast.NewObject(
@@ -98,7 +98,7 @@ func (p *MultiResourcePolicy) Eval(
 	}
 	err = options.RegoState.Query(
 		ctx,
-		query.Add(rego.Query{Query: p.resourcesRule.query()}),
+		query.Add(rego.Query{Query: p.resourcesRule.queryElem()}),
 		processor.ProcessResource,
 	)
 	if err != nil {

--- a/pkg/policy/single.go
+++ b/pkg/policy/single.go
@@ -31,6 +31,7 @@ import (
 // SingleResourcePolicy represents a policy that takes a single resource as input.
 type SingleResourcePolicy struct {
 	*BasePolicy
+	Query            string
 	processorFactory func(
 		resource *models.ResourceState,
 		metadata *Metadata,
@@ -105,7 +106,7 @@ func (p *SingleResourcePolicy) Eval(
 				ctx,
 				rego.Query{
 					Tracers: []topdown.QueryTracer{tracer},
-					Query:   p.judgementRule.query(),
+					Query:   p.Query,
 					Input:   inputDoc.Value,
 				},
 				func(val ast.Value) error {

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -119,3 +119,19 @@ func TestSnykRules(t *testing.T) {
 	assert.NoError(t, err)
 	utils.GoldenTest(t, "snykrules.json", bytes)
 }
+
+func TestRegression(t *testing.T) {
+	results := RunEngine(
+		t,
+		&engine.EngineOptions{
+			Providers: []data.Provider{
+				data.LocalProvider("regression"),
+			},
+		},
+		"../examples/main.tf",
+	)
+	assert.Len(t, results.Results, 1)
+	bytes, err := json.MarshalIndent(results.Results[0].RuleResults, "", "  ")
+	assert.NoError(t, err)
+	utils.GoldenTest(t, "regression.json", bytes)
+}

--- a/test/regression.json
+++ b/test/regression.json
@@ -1,0 +1,81 @@
+[
+  {
+    "rule_bundle": {
+      "source": "data"
+    },
+    "resource_types": [
+      "aws_s3_bucket"
+    ],
+    "results": [
+      {
+        "passed": false,
+        "ignored": false,
+        "message": "Bucket names should not contain bucket",
+        "resource_id": "aws_s3_bucket.bucket1",
+        "resource_namespace": "../examples/main.tf",
+        "resource_type": "aws_s3_bucket",
+        "resources": [
+          {
+            "id": "aws_s3_bucket.bucket1",
+            "type": "aws_s3_bucket",
+            "namespace": "../examples/main.tf",
+            "location": [
+              {
+                "filepath": "../examples/main.tf",
+                "line": 5,
+                "column": 1
+              }
+            ],
+            "attributes": [
+              {
+                "path": [
+                  "bucket"
+                ],
+                "location": {
+                  "filepath": "../examples/main.tf",
+                  "line": 6,
+                  "column": 3
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "passed": false,
+        "ignored": false,
+        "message": "Bucket names should not contain bucket",
+        "resource_id": "aws_s3_bucket.bucket3",
+        "resource_namespace": "../examples/main.tf",
+        "resource_type": "aws_s3_bucket",
+        "resources": [
+          {
+            "id": "aws_s3_bucket.bucket3",
+            "type": "aws_s3_bucket",
+            "namespace": "../examples/main.tf",
+            "location": [
+              {
+                "filepath": "../examples/main.tf",
+                "line": 37,
+                "column": 1
+              }
+            ],
+            "attributes": [
+              {
+                "path": [
+                  "bucket"
+                ],
+                "location": {
+                  "filepath": "../examples/main.tf",
+                  "line": 38,
+                  "column": 3
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "package": "data.rules.norulekey"
+  }
+]

--- a/test/regression/norulekey.rego
+++ b/test/regression/norulekey.rego
@@ -1,0 +1,28 @@
+package rules.norulekey
+
+import data.snyk
+
+buckets = snyk.resources("aws_s3_bucket")
+
+bucket_name_contains(bucket, needle) {
+	is_string(bucket.bucket)
+	contains(bucket.bucket, needle)
+}
+
+bucket_name_contains(bucket, needle) {
+	is_string(bucket.bucket_prefix)
+	contains(bucket.bucket_prefix, needle)
+}
+
+make_deny(needle) = ret {
+	ret := {info |
+		bucket := buckets[_]
+		bucket_name_contains(bucket, needle)
+		info := {
+			"message": sprintf("Bucket names should not contain %s", [needle]),
+			"resource": bucket,
+		}
+	}
+}
+
+deny = make_deny("bucket")


### PR DESCRIPTION
In #193 we added some code to make `query()` return different queries based on whether or not the underlying rule has a key.

For example, it would return:

-   the query `deny` for the rule `deny { false }`
-   the query `deny[_]` for the rule `deny[info] { info = "foo" }`

However, this is inherently flawed since it is purely based on the syntax of the underlying rule, and not its semantics.  For examples, these two shapes of rules should be handled the same way:

-   `deny[info] { ... }`
-   `deny = library.make_deny(...)`

The code interpreting the result _already knows_ if it's expecting a set or a single result, and that's what the query should be based on -- not the syntax of the rule.

To fix this, I added two queries, `query` and `queryElem`.

---

When researching other uses of `hasKey()`, I found that we are also using this incorrectly to classify rules in the factory code.  The appropriate thing to do there seems to use OPA's typing modules to look at the _type_ of the judgement rule rather than the _syntax_.  That's out of scope for this PR though, since it seems that was already an issue before the introduction of #193.