### PR TITLE
fix: allow path in ClientConfig.URL

### DIFF
--- a/changes/unreleased/Fixed-20230426-081611.yaml
+++ b/changes/unreleased/Fixed-20230426-081611.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: bug where paths, e.g. /api, were dropped from cloudapi.ClientConfig.URL
+time: 2023-04-26T08:16:11.678605-04:00

--- a/pkg/input/cloudapi/client.go
+++ b/pkg/input/cloudapi/client.go
@@ -71,6 +71,7 @@ func NewClient(config ClientConfig) (*Client, error) {
 	sanitizedURL := url.URL{
 		Scheme: parsedURL.Scheme,
 		Host:   parsedURL.Host,
+		Path:   parsedURL.Path,
 	}
 
 	httpClient := config.HTTPClient

--- a/pkg/input/cloudapi/client_test.go
+++ b/pkg/input/cloudapi/client_test.go
@@ -51,7 +51,7 @@ func TestClient(t *testing.T) {
 				URL:   "https://api.dev.snyk.io/api/v1",
 				Token: "some-token",
 			},
-			expectedURL:           "https://api.dev.snyk.io",
+			expectedURL:           "https://api.dev.snyk.io/api/v1",
 			expectedAuthorization: "some-token",
 			expectedVersion:       defaultVersion,
 		},


### PR DESCRIPTION
This PR fixes a bug where paths in ClientConfig.URL were being removed. Some Snyk environments require a path, e.g. `/api`, so we need to retain the path in the sanitized URL.