### PR TITLE
fix: messages produced by rules without messages

### DIFF
--- a/changes/unreleased/Fixed-20230427-152428.yaml
+++ b/changes/unreleased/Fixed-20230427-152428.yaml
@@ -1,0 +1,4 @@
+kind: Fixed
+body: rules without messages produce messages containing '\n\n' when they produce
+  multiple results
+time: 2023-04-27T15:24:28.827257-04:00

--- a/pkg/policy/ruleresultbuilder.go
+++ b/pkg/policy/ruleresultbuilder.go
@@ -114,9 +114,18 @@ func (builder *ruleResultBuilder) toRuleResult() models.RuleResult {
 		resources = append(resources, builder.resources[k])
 	}
 
-	// Gather messages.
-	messages := make([]string, len(builder.messages))
-	copy(messages, builder.messages)
+	// Gather unique, non-blank messages.
+	var messages []string
+	seenMessages := map[string]bool{}
+	for _, m := range builder.messages {
+		if m == "" {
+			continue
+		}
+		if _, seen := seenMessages[m]; !seen {
+			messages = append(messages, m)
+			seenMessages[m] = true
+		}
+	}
 	sort.Strings(messages)
 
 	// Infer primary resource.


### PR DESCRIPTION
This PR fixes a bug where rules without messages would produce messages that only contained newlines, like `"\n\n"` if they produced multiple results.