### PR TITLE
feat: add sentinel errors for non fatal errors [CLOUD-1439]

### DIFF
--- a/changes/unreleased/Added-20230501-160449.yaml
+++ b/changes/unreleased/Added-20230501-160449.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: sentiel errors for non-fatal errors
+time: 2023-05-01T16:04:49.004689+03:00

--- a/pkg/hcl_interpreter/errors.go
+++ b/pkg/hcl_interpreter/errors.go
@@ -1,0 +1,29 @@
+// © 2022-2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hcl_interpreter
+
+import (
+	"errors"
+)
+
+var ErrLoadRemoteSubmodules = errors.New("Could not load some remote submodules")
+
+var ErrEvaluation = errors.New("Evaluation error")
+
+var ErrUnhandledValueType = errors.New("Unhandled value type")
+
+var ErrBadDependencyKey = errors.New("Bad dependency key")
+
+var ErrMissingTerm = errors.New("Missing term")

--- a/pkg/hcl_interpreter/errors.go
+++ b/pkg/hcl_interpreter/errors.go
@@ -16,14 +16,35 @@ package hcl_interpreter
 
 import (
 	"errors"
+
+	"github.com/hashicorp/hcl/v2"
 )
 
-var ErrLoadRemoteSubmodules = errors.New("Could not load some remote submodules")
+type MissingRemoteSubmodulesError struct {
+	Dir            string
+	MissingModules []string
+}
 
-var ErrEvaluation = errors.New("Evaluation error")
+func (err MissingRemoteSubmodulesError) Error() string {
+	return "Could not load some remote submodules"
+}
 
-var ErrUnhandledValueType = errors.New("Unhandled value type")
+type EvaluationError struct {
+	Diags hcl.Diagnostics
+}
 
-var ErrBadDependencyKey = errors.New("Bad dependency key")
+func (err EvaluationError) Error() string {
+	return "Evaluation error"
+}
 
-var ErrMissingTerm = errors.New("Missing term")
+type MissingTermError struct {
+	Term string
+}
+
+func (err MissingTermError) Error() string {
+	return "Missing term " + err.Term
+}
+
+var errUnhandledValueType = errors.New("Unhandled value type")
+
+var errBadDependencyKey = errors.New("Bad dependency key")

--- a/pkg/hcl_interpreter/hcl_interpreter.go
+++ b/pkg/hcl_interpreter/hcl_interpreter.go
@@ -18,6 +18,7 @@ package hcl_interpreter
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/hcl/v2"
 	"github.com/spf13/afero"
 	"github.com/zclconf/go-cty/cty"
@@ -267,7 +268,7 @@ func (v *Evaluation) evaluate() error {
 		})
 
 		if diags.HasErrors() {
-			v.errors = append(v.errors, fmt.Errorf("evaluate: error: %s", diags))
+			v.errors = append(v.errors, fmt.Errorf("%w: %v", ErrEvaluation, diags))
 		}
 
 		v.resourceAttributes[name.ToString()] = val
@@ -385,10 +386,10 @@ func (v *Evaluation) Resources() []Resource {
 func (e *Evaluation) Errors() []error {
 	errors := []error{}
 	for badKey := range e.Analysis.badKeys {
-		errors = append(errors, fmt.Errorf("Bad dependency key: %s", badKey))
+		errors = append(errors, fmt.Errorf("%w: %v", ErrBadDependencyKey, badKey))
 	}
 	for missingTerm := range e.Analysis.missingTerms {
-		errors = append(errors, fmt.Errorf(`Missing term for "%s", substituted in as string`, missingTerm))
+		errors = append(errors, fmt.Errorf("%w: %v", ErrMissingTerm, missingTerm))
 	}
 	errors = append(errors, e.errors...)
 	return errors

--- a/pkg/hcl_interpreter/hcl_interpreter.go
+++ b/pkg/hcl_interpreter/hcl_interpreter.go
@@ -268,7 +268,7 @@ func (v *Evaluation) evaluate() error {
 		})
 
 		if diags.HasErrors() {
-			v.errors = append(v.errors, fmt.Errorf("%w: %v", ErrEvaluation, diags))
+			v.errors = append(v.errors, EvaluationError{diags})
 		}
 
 		v.resourceAttributes[name.ToString()] = val
@@ -386,10 +386,10 @@ func (v *Evaluation) Resources() []Resource {
 func (e *Evaluation) Errors() []error {
 	errors := []error{}
 	for badKey := range e.Analysis.badKeys {
-		errors = append(errors, fmt.Errorf("%w: %v", ErrBadDependencyKey, badKey))
+		errors = append(errors, fmt.Errorf("%w: %v", errBadDependencyKey, badKey))
 	}
 	for missingTerm := range e.Analysis.missingTerms {
-		errors = append(errors, fmt.Errorf("%w: %v", ErrMissingTerm, missingTerm))
+		errors = append(errors, MissingTermError{missingTerm})
 	}
 	errors = append(errors, e.errors...)
 	return errors

--- a/pkg/hcl_interpreter/moduletree.go
+++ b/pkg/hcl_interpreter/moduletree.go
@@ -183,11 +183,7 @@ func (mtree *ModuleTree) Errors() []error {
 
 	missingModules := mtree.meta.MissingRemoteModules
 	if len(missingModules) > 0 {
-		missingModulesList := strings.Join(missingModules, ", ")
-
-		errors = append(errors, fmt.Errorf(
-			"%w: %s: %s", ErrLoadRemoteSubmodules, mtree.meta.Dir, missingModulesList,
-		))
+		errors = append(errors, MissingRemoteSubmodulesError{mtree.meta.Dir, missingModules})
 	}
 
 	for _, child := range mtree.children {

--- a/pkg/hcl_interpreter/moduletree.go
+++ b/pkg/hcl_interpreter/moduletree.go
@@ -184,18 +184,9 @@ func (mtree *ModuleTree) Errors() []error {
 	missingModules := mtree.meta.MissingRemoteModules
 	if len(missingModules) > 0 {
 		missingModulesList := strings.Join(missingModules, ", ")
-		firstSentence := "Could not load some remote submodules"
-		if mtree.meta.Dir != "." {
-			firstSentence += fmt.Sprintf(
-				" that are used by '%s'",
-				mtree.meta.Dir,
-			)
-		}
 
 		errors = append(errors, fmt.Errorf(
-			"%s. Run 'terraform init' if you would like to include them in the evaluation: %s",
-			firstSentence,
-			missingModulesList,
+			"%w: %s: %s", ErrLoadRemoteSubmodules, mtree.meta.Dir, missingModulesList,
 		))
 	}
 

--- a/pkg/hcl_interpreter/value.go
+++ b/pkg/hcl_interpreter/value.go
@@ -89,5 +89,5 @@ func ValueToInterface(val cty.Value) (interface{}, []error) {
 		return object, nil
 	}
 
-	return nil, []error{fmt.Errorf("%w: %v", ErrUnhandledValueType, val.Type().GoString())}
+	return nil, []error{fmt.Errorf("%w: %v", errUnhandledValueType, val.Type().GoString())}
 }

--- a/pkg/hcl_interpreter/value.go
+++ b/pkg/hcl_interpreter/value.go
@@ -89,5 +89,5 @@ func ValueToInterface(val cty.Value) (interface{}, []error) {
 		return object, nil
 	}
 
-	return nil, []error{fmt.Errorf("Unhandled value type: %s", val.Type().GoString())}
+	return nil, []error{fmt.Errorf("%w: %v", ErrUnhandledValueType, val.Type().GoString())}
 }


### PR DESCRIPTION
As part of the work to provide users of Snyk Integrated IaC a better output for non-fatal errors we need to create sentinel errors that the PE will produce and `snyk-iac-test` will consume and process. 


### Relevant Tickets
https://snyksec.atlassian.net/browse/CFG-2258
https://snyksec.atlassian.net/browse/CLOUD-1439
