### PR TITLE
feat: expose the embedded version info for terraform

### DIFF
--- a/changes/unreleased/Added-20230509-100822.yaml
+++ b/changes/unreleased/Added-20230509-100822.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: expose the embedded version info for terraform
+time: 2023-05-09T10:08:22.002574523+02:00

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,6 +17,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/snyk/policy-engine/pkg/version"
 	"github.com/spf13/cobra"
@@ -27,13 +28,32 @@ var versionCmd = &cobra.Command{
 	Short: "Display version",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		v := version.GetVersionInfo()
-		fmt.Fprintf(os.Stdout, "Version:\t%s\n", v.Version)
-		fmt.Fprintf(os.Stdout, "OPA Version:\t%s\n", v.OPAVersion)
+
+		table := [][2]string{}
+		table = append(table, [2]string{"Version", v.Version})
+		table = append(table, [2]string{"OPA Version", v.OPAVersion})
+		table = append(table, [2]string{"Terraform Version", v.TerraformVersion})
 		revision := v.Revision
 		if v.HasChanges {
 			revision = fmt.Sprintf("%s*", revision)
 		}
-		fmt.Fprintf(os.Stdout, "Revision:\t%s\n", revision)
+		table = append(table, [2]string{"Revision", revision})
+
+		padding := 0
+		for _, row := range table {
+			if len(row[0]) > padding {
+				padding = len(row[0])
+			}
+		}
+
+		for _, row := range table {
+			fmt.Fprintf(os.Stdout, "%s:%s%s\n",
+				row[0],
+				strings.Repeat(" ", padding-len(row[0])+1),
+				row[1],
+			)
+		}
+
 		return nil
 	},
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -18,7 +18,8 @@ import (
 	"runtime/debug"
 	"strings"
 
-	"github.com/open-policy-agent/opa/version"
+	opaversion "github.com/open-policy-agent/opa/version"
+	tfversion "github.com/snyk/policy-engine/pkg/internal/terraform/version"
 )
 
 // Default build-time variables.
@@ -29,13 +30,18 @@ var (
 )
 
 // OPAVersion is the canonical version of OPA that is embedded in policy-engine
-var OPAVersion = version.Version
+var OPAVersion = opaversion.Version
+
+// Terraform holds the embedded version of terraform.
+var TerraformVersion = tfversion.Version
 
 type VersionInfo struct {
 	// Version is set to the most recent tag at build time
 	Version string
 	// OPAversion is the canonical version of OPA that is embedded in policy-engine
 	OPAVersion string
+	// Terraform holds the embedded version of terraform.
+	TerraformVersion string
 	// Revision is the git commit hash at build time
 	Revision string
 	// HasChanges reflects whether or not the source tree had changes at build time
@@ -44,8 +50,9 @@ type VersionInfo struct {
 
 func GetVersionInfo() VersionInfo {
 	v := VersionInfo{
-		Version:    Version,
-		OPAVersion: OPAVersion,
+		Version:          Version,
+		OPAVersion:       OPAVersion,
+		TerraformVersion: TerraformVersion,
 	}
 	if info, ok := debug.ReadBuildInfo(); ok {
 		for _, setting := range info.Settings {


### PR DESCRIPTION
```
> go build && ./policy-engine version
Version:           unknown-version
OPA Version:       0.46.0-dev
Terraform Version: 1.3.8
Revision:          949acd82eb01ba1cd306730804def2b81f12e371*
```