### PR TITLE
feat: new sentinel error for loading submodule error

### DIFF
--- a/changes/unreleased/Added-20230509-120632.yaml
+++ b/changes/unreleased/Added-20230509-120632.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Added a new sentinel error when we recieve an error when loading a submodule
+time: 2023-05-09T12:06:32.826785+03:00

--- a/pkg/hcl_interpreter/errors.go
+++ b/pkg/hcl_interpreter/errors.go
@@ -16,9 +16,19 @@ package hcl_interpreter
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 )
+
+type SubmoduleLoadingError struct {
+	Module string
+	Err    error
+}
+
+func (err SubmoduleLoadingError) Error() string {
+	return "Error loading submodule " + err.Module + ": " + err.Err.Error()
+}
 
 type MissingRemoteSubmodulesError struct {
 	Dir            string
@@ -26,7 +36,7 @@ type MissingRemoteSubmodulesError struct {
 }
 
 func (err MissingRemoteSubmodulesError) Error() string {
-	return "Could not load some remote submodules"
+	return "Could not load remote submodules in " + err.Dir + ": " + strings.Join(err.MissingModules, ", ")
 }
 
 type EvaluationError struct {
@@ -34,7 +44,7 @@ type EvaluationError struct {
 }
 
 func (err EvaluationError) Error() string {
-	return "Evaluation error"
+	return "Evaluation error: " + err.Diags.Error()
 }
 
 type MissingTermError struct {

--- a/pkg/hcl_interpreter/moduletree.go
+++ b/pkg/hcl_interpreter/moduletree.go
@@ -165,7 +165,7 @@ func ParseFiles(
 						} else {
 							errors = append(
 								errors,
-								fmt.Errorf("Error loading submodule '%s': %s", key, err),
+								SubmoduleLoadingError{key, err},
 							)
 						}
 					}


### PR DESCRIPTION
Following the chat [here](https://snyk.slack.com/archives/C04CQ0D2VFH/p1683556057785469), I've added a new sentinel error when we get an error when loading a submodule.