### PR TITLE
chore: update and run license script

### DIFF
--- a/changes/unreleased/Fixed-20230525-111249.yaml
+++ b/changes/unreleased/Fixed-20230525-111249.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: small bug in license script
+time: 2023-05-25T11:12:49.709247-04:00

--- a/cmd/cloud.go
+++ b/cmd/cloud.go
@@ -1,3 +1,17 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmd
 
 import (

--- a/cmd/verbosity.go
+++ b/cmd/verbosity.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Snyk Limited All rights reserved.
+// © 2023 Snyk Limited All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/input/cloud_loader.go
+++ b/pkg/input/cloud_loader.go
@@ -1,3 +1,17 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package input
 
 import (

--- a/pkg/input/cloud_loader_test.go
+++ b/pkg/input/cloud_loader_test.go
@@ -1,3 +1,17 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package input_test
 
 import (

--- a/pkg/input/cloudapi/client.go
+++ b/pkg/input/cloudapi/client.go
@@ -1,3 +1,17 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cloudapi
 
 import (

--- a/pkg/input/cloudapi/client_test.go
+++ b/pkg/input/cloudapi/client_test.go
@@ -1,3 +1,17 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cloudapi
 
 import (

--- a/pkg/input/cloudapi/resources.go
+++ b/pkg/input/cloudapi/resources.go
@@ -1,3 +1,17 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cloudapi
 
 import (

--- a/pkg/input/cloudapi/resources_test.go
+++ b/pkg/input/cloudapi/resources_test.go
@@ -1,3 +1,17 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cloudapi
 
 import (

--- a/pkg/input/golden_test/tf/dynamic-block-william/terraform.tf
+++ b/pkg/input/golden_test/tf/dynamic-block-william/terraform.tf
@@ -1,3 +1,17 @@
+# © 2023 Snyk Limited All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # What we expect to see after a plan
 resource "aws_s3_bucket" "one" {
   bucket = "one"

--- a/pkg/input/golden_test/tf/dynamic-block-william/variables.tf
+++ b/pkg/input/golden_test/tf/dynamic-block-william/variables.tf
@@ -1,3 +1,17 @@
+# © 2023 Snyk Limited All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "lifecycle_rules" {
   description = "List of maps containing configuration of object lifecycle management."
   type        = any

--- a/pkg/input/golden_test/tf/dynamic-block/dynamic-block.tf
+++ b/pkg/input/golden_test/tf/dynamic-block/dynamic-block.tf
@@ -1,3 +1,17 @@
+# © 2023 Snyk Limited All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 locals {
   ports = [
     443, 80, 22

--- a/pkg/input/golden_test/tf/regula-issue-397/main.tf
+++ b/pkg/input/golden_test/tf/regula-issue-397/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2023 Snyk Limited All rights reserved.
+# © 2023 Snyk Limited All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pkg/internal/withtimeout/do.go
+++ b/pkg/internal/withtimeout/do.go
@@ -1,3 +1,17 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package withtimeout
 
 import (

--- a/pkg/policy/allowlist.go
+++ b/pkg/policy/allowlist.go
@@ -1,3 +1,17 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package policy
 
 // We are a paranoid security company so we use an allowlist rather than a

--- a/pkg/policy/api_test.go
+++ b/pkg/policy/api_test.go
@@ -1,3 +1,17 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package policy
 
 import (

--- a/pkg/rego/bind.go
+++ b/pkg/rego/bind.go
@@ -1,3 +1,17 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rego
 
 import (

--- a/pkg/rego/bind_test.go
+++ b/pkg/rego/bind_test.go
@@ -1,3 +1,17 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rego
 
 import (

--- a/pkg/rego/query.go
+++ b/pkg/rego/query.go
@@ -1,3 +1,17 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rego
 
 import (

--- a/pkg/rego/query_test.go
+++ b/pkg/rego/query_test.go
@@ -1,3 +1,17 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package rego
 
 import (

--- a/scripts/license.py
+++ b/scripts/license.py
@@ -60,7 +60,7 @@ def license_file(path, comment_prefix):
     copyrights_list = reversed(sorted(list(copyrights.items()), key=lambda x: x[1][1]))
     for (holder, (start_year, end_year)) in copyrights_list:
         years = start_year if start_year == end_year else f"{start_year}-{end_year}"
-        new_lines.append(f"{comment_prefix} Copyright {years} {holder}\n")
+        new_lines.append(f"{comment_prefix} © {years} {holder}\n")
     if copyrights_end is not None:
         new_lines += lines[copyrights_end:]
     else:


### PR DESCRIPTION
This PR fixes a tiny bug in the license script and updates the license blocks wherever needed.