### PR TITLE
refactor: CLOUD-1495 rename informational severity to info

### DIFF
--- a/changes/unreleased/Changed-20230530-095629.yaml
+++ b/changes/unreleased/Changed-20230530-095629.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: informational severity to info
+time: 2023-05-30T09:56:29.948894-04:00

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -276,7 +276,7 @@ components:
             - high
             - medium
             - low
-            - informational
+            - info
         context:
           type: object
           description: An arbitrary key-value map that a rule can return in its result.


### PR DESCRIPTION
This commit renames the informational severity to info in order to align with Snyk.

This change has no functional effect within `policy-engine`, but could affect clients generated from these specs.