### PR TITLE
fix: CLOUD-1495 missing rule result fields

### DIFF
--- a/changes/unreleased/Fixed-20230530-160602.yaml
+++ b/changes/unreleased/Fixed-20230530-160602.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: missing rule result fields when unmarshalled
+time: 2023-05-30T16:06:02.966796-04:00

--- a/pkg/models/compat.go
+++ b/pkg/models/compat.go
@@ -70,6 +70,8 @@ func (r *RuleResults) UnmarshalJSON(data []byte) error {
 		Results       []RuleResult           `json:"results"`
 		Errors        []string               `json:"errors,omitempty"`
 		Package_      string                 `json:"package,omitempty"`
+		Kind          string                 `json:"kind,omitempty"`
+		RuleBundle    *RuleBundle            `json:"rule_bundle,omitempty"`
 	}{}
 	err := json.Unmarshal(data, &compat)
 	if err != nil {
@@ -90,5 +92,7 @@ func (r *RuleResults) UnmarshalJSON(data []byte) error {
 	r.Results = compat.Results
 	r.Errors = compat.Errors
 	r.Package_ = compat.Package_
+	r.Kind = compat.Kind
+	r.RuleBundle = compat.RuleBundle
 	return nil
 }

--- a/test/examples.json
+++ b/test/examples.json
@@ -684,6 +684,7 @@
           "package": "data.rules.snyk_001.tf"
         },
         {
+          "kind": "vulnerability",
           "rule_bundle": {
             "source": "data"
           },
@@ -829,6 +830,7 @@
           "package": "data.rules.snyk_002.tf"
         },
         {
+          "kind": "vulnerability",
           "rule_bundle": {
             "source": "data"
           },
@@ -908,6 +910,7 @@
           "package": "data.rules.snyk_003.tf"
         },
         {
+          "kind": "vulnerability",
           "rule_bundle": {
             "source": "data"
           },
@@ -1073,6 +1076,7 @@
           "package": "data.rules.snyk_004.tf"
         },
         {
+          "kind": "vulnerability",
           "rule_bundle": {
             "source": "data"
           },
@@ -1312,6 +1316,7 @@
           "package": "data.rules.snyk_005.tf"
         },
         {
+          "kind": "vulnerability",
           "rule_bundle": {
             "source": "data"
           },
@@ -1555,6 +1560,7 @@
           "package": "data.rules.snyk_005b.tf"
         },
         {
+          "kind": "vulnerability",
           "rule_bundle": {
             "source": "data"
           },
@@ -1798,6 +1804,7 @@
           "package": "data.rules.snyk_006.tf"
         },
         {
+          "kind": "vulnerability",
           "rule_bundle": {
             "source": "data"
           },
@@ -1915,6 +1922,7 @@
           "package": "data.rules.snyk_008.tf"
         },
         {
+          "kind": "vulnerability",
           "rule_bundle": {
             "source": "data"
           },
@@ -2051,6 +2059,7 @@
           "package": "data.rules.snyk_009.tf"
         },
         {
+          "kind": "vulnerability",
           "rule_bundle": {
             "source": "data"
           },

--- a/test/fuguerules.json
+++ b/test/fuguerules.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "FG_R00099",
+    "kind": "vulnerability",
     "rule_bundle": {
       "source": "data"
     },
@@ -47,6 +48,7 @@
     "package": "data.rules.fugue_advanced"
   },
   {
+    "kind": "vulnerability",
     "rule_bundle": {
       "source": "data"
     },
@@ -86,6 +88,7 @@
     "package": "data.rules.fugue_simple_allow_boolean"
   },
   {
+    "kind": "vulnerability",
     "rule_bundle": {
       "source": "data"
     },
@@ -127,6 +130,7 @@
     "package": "data.rules.fugue_simple_allow_string"
   },
   {
+    "kind": "vulnerability",
     "rule_bundle": {
       "source": "data"
     },
@@ -166,6 +170,7 @@
     "package": "data.rules.fugue_simple_deny_boolean"
   },
   {
+    "kind": "vulnerability",
     "rule_bundle": {
       "source": "data"
     },
@@ -311,6 +316,7 @@
     "package": "data.rules.fugue_simple_deny_info"
   },
   {
+    "kind": "vulnerability",
     "rule_bundle": {
       "source": "data"
     },

--- a/test/regression.json
+++ b/test/regression.json
@@ -1,5 +1,6 @@
 [
   {
+    "kind": "vulnerability",
     "rule_bundle": {
       "source": "data"
     },


### PR DESCRIPTION
This PR fixes a bug where rule results that are unmarshalled using the model classes that we provide were missing the Kind and RuleBundle fields.

It also fixes a logic bug that caused Kind to be missing when no metadata rule was defined.

The unmarshal bug was quite tricky, because new metadata and rule result fields have to be added in a few places. We should follow up with a longer term fix that removes the backwards compatibility code, because it's no longer needed. That means that we'll also need to go through every consumer to ensure that all test data has been updated.