### PR TITLE
feat: search for input files recursively (CLOUD-1611)

### DIFF
--- a/changes/unreleased/Added-20230622-121705.yaml
+++ b/changes/unreleased/Added-20230622-121705.yaml
@@ -1,0 +1,4 @@
+kind: Added
+body: '`policy-engine run` will now search for IaC configurations recursively if passed
+  a directory'
+time: 2023-06-22T12:17:05.788148288+02:00

--- a/changes/unreleased/Changed-20230622-121735.yaml
+++ b/changes/unreleased/Changed-20230622-121735.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: '`input.Loader` detects and avoids duplicate file loads'
+time: 2023-06-22T12:17:35.356126986+02:00

--- a/docs/library_usage.md
+++ b/docs/library_usage.md
@@ -48,10 +48,10 @@ function to obtain a `Detector` for some set of input types:
 
 ```go
 detector, err := input.DetectorByInputTypes(
-  input.Types{input.Auto},
+	input.Types{input.Auto},
 )
 if err != nil {
-  return err
+	return err
 }
 ```
 
@@ -70,13 +70,13 @@ like:
 ```go
 // Note that these types take an afero.Fs: https://github.com/spf13/afero
 f := input.File{
-  Path: "path/to/some_file.json",
-  Fs: afero.OsFs{},
+	Path: "path/to/some_file.json",
+	Fs: afero.OsFs{},
 }
 
 d := input.Directory{
-  Path: "path/to/some_directory",
-  Fs: afero.OsFs{},
+	Path: "path/to/some_directory",
+	Fs: afero.OsFs{},
 }
 ```
 
@@ -112,7 +112,7 @@ dir := input.Directory{
 }
 walkFunc := func(d Detectable, depth int) (bool, error) {
 	// loader.Load returns true if the detectable contained an IaC configuration and was
-	// successfully loaded.  We want to keep recursing in either case.
+	// successfully loaded.	We want to keep recursing in either case.
 	_, err := loader.Load(d, input.DetectOptions{})
 	return false, err
 }
@@ -149,14 +149,14 @@ configurations for use with the `engine` package.
 ```go
 loader := input.NewLoader(detector)
 loaded, err := loader.Load(*input.File{
-  Fs: afero.OsFs{},
-  Path: "cloudformation.yaml",
+	Fs: afero.OsFs{},
+	Path: "cloudformation.yaml",
 })
 if err != nil {
-  // ...
+	// ...
 }
 if !loaded {
-  // ...
+	// ...
 }
 states := loaded.ToStates()
 ```
@@ -170,10 +170,10 @@ filepath.
 package main
 
 import (
-  "errors"
-  "fmt"
+	"errors"
+	"fmt"
 
-  "github.com/snyk/policy-engine/pkg/input"
+	"github.com/snyk/policy-engine/pkg/input"
 )
 
 func example(paths []string) {
@@ -283,7 +283,7 @@ func getCloudResources(ctx context.Context, query policy.ResourcesQuery) (policy
 	resources := fetchResourcesFromCloud(query.ResourceType, query.Scope["region"])
 	return policy.ResourcesResult{
 		ScopeFound: true,
-		Resources:  resources,
+		Resources:	resources,
 	}, nil
 }
 
@@ -292,13 +292,13 @@ func getCloudResources(ctx context.Context, query policy.ResourcesQuery) (policy
 Then, they can inject that into the engine's resolver chain at evaluation time:
 
 ```go
-  engine, err := upe.NewEngine(ctx, &upe.EngineOptions{
-    ...
-  })
-  results := engine.Eval(ctx, &engine.EvalOptions{
-    ...
-    ResourcesResolver: policy.ResourcesResolver(getCloudResources),
-  })
+	engine, err := upe.NewEngine(ctx, &upe.EngineOptions{
+		...
+	})
+	results := engine.Eval(ctx, &engine.EvalOptions{
+		...
+		ResourcesResolver: policy.ResourcesResolver(getCloudResources),
+	})
 ```
 
 Policies that make use of the "region" input scope field, which will not be set
@@ -341,17 +341,17 @@ package main
 import "github.com/snyk/policy-engine/pkg/bundle"
 
 func main() {
-  // ...
-  f, err := os.Open(path)
-  if err != nil {
-    return err
-  }
-  defer f.Close()
-  reader, err := bundle.NewTarGzReader(path, f)
-  if err != nil {
-    return err
-  }
-  // ...
+	// ...
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	reader, err := bundle.NewTarGzReader(path, f)
+	if err != nil {
+		return err
+	}
+	// ...
 }
 ```
 
@@ -366,10 +366,10 @@ package main
 import "github.com/snyk/policy-engine/pkg/bundle"
 
 func main() {
-  // ...
-  // where path is a path to a local directory
-  reader := bundle.NewDirReader(path)
-  // ...
+	// ...
+	// where path is a path to a local directory
+	reader := bundle.NewDirReader(path)
+	// ...
 }
 ```
 
@@ -382,18 +382,18 @@ conforms to the bundle spec via a given `io.FS` implementation.
 package main
 
 import (
-  "embed"
+	"embed"
 
-  "github.com/snyk/policy-engine/pkg/bundle"
+	"github.com/snyk/policy-engine/pkg/bundle"
 )
 
 //go:embed bundle_dir
 var embeddedBundle embed.FS
 
 func main() {
-  // ...
-  reader := bundle.NewFSReader("bundle_dir", embeddedBundle)
-  // ...
+	// ...
+	reader := bundle.NewFSReader("bundle_dir", embeddedBundle)
+	// ...
 }
 ```
 
@@ -412,9 +412,9 @@ useful for policies that are embedded via the `go:embed` directive:
 package main
 
 import (
-  "embed"
+	"embed"
 
-  "github.com/snyk/policy-engine/pkg/data"
+	"github.com/snyk/policy-engine/pkg/data"
 )
 
 //go:embed policies
@@ -425,7 +425,7 @@ var policiesFS embed.FS
 var policiesProvider = data.FSProvider(policiesFS, "policies")
 
 func main() {
-  // ...
+	// ...
 }
 ```
 
@@ -440,11 +440,11 @@ package main
 import "github.com/snyk/policy-engine/pkg/data"
 
 func main() {
-  // ...
-  providers := make([]data.Provider, len(paths))
-  for idx, path := range paths {
-    providers[idx] = data.LocalProvider(path)
-  }
+	// ...
+	providers := make([]data.Provider, len(paths))
+	for idx, path := range paths {
+		providers[idx] = data.LocalProvider(path)
+	}
 }
 ```
 
@@ -464,52 +464,52 @@ package main
 import "github.com/snyk/policy-engine/pkg/engine"
 
 func main() {
-  ctx := context.Background()
-  // ...
-  eng := engine.NewEngine(ctx, &engine.EngineOptions{
-    // BundleReaders contains bundle.Reader objects. See above for descriptions
-    // of the reader implementations included in this library.
-    BundleReaders: readers,
-    // This is an optional instance of the logger.Logger interface. This interface is
-    // compatible with the one provided by the snyk/go-common library. The logger
-    // package also contains an implementation of this interface.
-    Logger:    logger,
-    // This is an optional instance of the metrics.Metrics interface. This interface is
-    // compatible with the one provided by the snyk/go-common library. The metrics
-    // package also contains an implementation of this interface.
-    Metrics:   m,
-  })
+	ctx := context.Background()
+	// ...
+	eng := engine.NewEngine(ctx, &engine.EngineOptions{
+		// BundleReaders contains bundle.Reader objects. See above for descriptions
+		// of the reader implementations included in this library.
+		BundleReaders: readers,
+		// This is an optional instance of the logger.Logger interface. This interface is
+		// compatible with the one provided by the snyk/go-common library. The logger
+		// package also contains an implementation of this interface.
+		Logger:		logger,
+		// This is an optional instance of the metrics.Metrics interface. This interface is
+		// compatible with the one provided by the snyk/go-common library. The metrics
+		// package also contains an implementation of this interface.
+		Metrics:	 m,
+	})
 
-  // Errors that occurred during the initialization process will be contained in
-  // eng.Errors
-  for _, err := range eng.Errors {
-    if err != nil {
-      // Checking for specific errors
-      switch {
-      case errors.Is(err, engine.ErrFailedToReadBundle):
-        // ...
-      case errors.Is(err, engine.FailedToLoadRules):
-        // ...
-      default:
-        // ...
-      }
-    }
-  }
+	// Errors that occurred during the initialization process will be contained in
+	// eng.Errors
+	for _, err := range eng.Errors {
+		if err != nil {
+			// Checking for specific errors
+			switch {
+			case errors.Is(err, engine.ErrFailedToReadBundle):
+				// ...
+			case errors.Is(err, engine.FailedToLoadRules):
+				// ...
+			default:
+				// ...
+			}
+		}
+	}
 
-  // This function returns a *models.Results
-  results := eng.Eval(ctx, &engine.EvalOptions{
-    // This option is used to determine which policies are executed. When this option is
-    // empty or unspecified, all policies will be run.
-    RuleIDs:   selectedPolicies,
-    // Inputs is a []models.State, like the output of the loader.ToStates()
-    // described above.
-    Inputs: states,
-    // ResourceResolvers is a list of functions that return a resource state for
-    // the given ResourceRequest. They will be invoked in order until a result is
-    // returned with ScopeFound set to true.
-    ResourcesResolvers []policy.ResourcesResolver,
-  })
-  
+	// This function returns a *models.Results
+	results := eng.Eval(ctx, &engine.EvalOptions{
+		// This option is used to determine which policies are executed. When this option is
+		// empty or unspecified, all policies will be run.
+		RuleIDs:	 selectedPolicies,
+		// Inputs is a []models.State, like the output of the loader.ToStates()
+		// described above.
+		Inputs: states,
+		// ResourceResolvers is a list of functions that return a resource state for
+		// the given ResourceRequest. They will be invoked in order until a result is
+		// returned with ScopeFound set to true.
+		ResourcesResolvers []policy.ResourcesResolver,
+	})
+
 }
 ```
 
@@ -563,19 +563,19 @@ Building on top of both the ["parsing IaC configurations" example](#example) and
 package main
 
 import (
-    "github.com/snyk/policy-engine/pkg/input",
-    "github.com/snyk/policy-engine/pkg/engine"
-    "github.com/snyk/policy-engine/pkg/postprocess"
+	"github.com/snyk/policy-engine/pkg/input",
+	"github.com/snyk/policy-engine/pkg/engine"
+	"github.com/snyk/policy-engine/pkg/postprocess"
 )
 
 func main() {
-    // Code that initializes a loader and produces results with engine from the
-    // previous examples
-    // ...
+	// Code that initializes a loader and produces results with engine from the
+	// previous examples
+	// ...
 
-    // AddSourceLocs modifies the results object in-place to add source
-    // code locations to resources and properties for supported input types.
-    postprocess.AddSourceLocs(results, loader)
+	// AddSourceLocs modifies the results object in-place to add source
+	// code locations to resources and properties for supported input types.
+	postprocess.AddSourceLocs(results, loader)
 }
 ```
 

--- a/pkg/input/loader.go
+++ b/pkg/input/loader.go
@@ -60,6 +60,16 @@ func NewLoader(detector Detector) Loader {
 // and false otherwise.
 func (l *Loader) Load(detectable Detectable, detectOpts DetectOptions) (bool, error) {
 	path := detectable.GetPath()
+	if _, ok := l.loadedPaths[path]; ok {
+		// Do not load any files that are already loaded.  E.g. if you have
+		//
+		//     foo/main.tf
+		//     foo/module/bar.tf
+		//
+		// And `foo/` includes `foo/module/bar.tf`, we do not want to load the
+		// latter again separately.
+		return false, nil
+	}
 	conf, err := detectable.DetectType(l.detector, detectOpts)
 	if err != nil {
 		return false, err

--- a/pkg/input/test_inputs/multiple_files/main.tf
+++ b/pkg/input/test_inputs/multiple_files/main.tf
@@ -1,0 +1,17 @@
+# © 2022-2023 Snyk Limited All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "aws_s3_bucket" "bucket1" {
+  bucket = "bucket1"
+}

--- a/pkg/input/test_inputs/multiple_files/main.yaml
+++ b/pkg/input/test_inputs/multiple_files/main.yaml
@@ -1,0 +1,19 @@
+# © 2022-2023 Snyk Limited All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+Resources:
+  MyVpc:
+    Type: Vpc
+    Properties:
+      Name: bar


### PR DESCRIPTION
This contains two small changes that work together.

 -  The `policy-engine run` command will now search for IaC configurations recursively if passed a directory.
 -  `input.Loader` will now avoid loading files twice, to prevent spurious duplicate files from the above change.

Test changes:

 -  I found the `ExampleLoader_Load()` function which we were not actually running in the tests, so I fixed that.
 -  I added a new `TestLoadInputsOnce` test together with a new `pkg/input/test_inputs/multiple_files/` directory to cover the case reported by the customer.
 
 **Suggestion**: when reviewing, add `?w=1` to the URL to ignore the tabs/spaces fixes I did in the library docs: https://github.com/snyk/policy-engine/pull/231/files?w=1