### PR TITLE
[CLOUD-1573]: Initial support for evaluating ARM template expressions

### DIFF
--- a/changes/unreleased/Added-20230627-100510.yaml
+++ b/changes/unreleased/Added-20230627-100510.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Initial support for evaluating ARM template expressions
+time: 2023-06-27T10:05:10.821405+01:00

--- a/pkg/input/arm/errors.go
+++ b/pkg/input/arm/errors.go
@@ -1,0 +1,43 @@
+// © 2022-2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arm
+
+import "fmt"
+
+type ErrorKind string
+
+const (
+	TokenizerError      ErrorKind = "TokenizerError"
+	ParserError         ErrorKind = "ParserError"
+	EvalError           ErrorKind = "EvalError"
+	UnsupportedFunction ErrorKind = "UnsupportedFunction"
+)
+
+// We have this error type so that we can use its `kind` as a metric label in
+// the future. Since callers in practice do not pass in a metrics collector
+// currently, we do nothing with it yet.
+type Error struct {
+	underlying error
+	expression string
+	kind       ErrorKind
+}
+
+func (e Error) Kind() ErrorKind {
+	return e.kind
+}
+
+func (e Error) Error() string {
+	return fmt.Sprintf("error evaluating expression '%s': %s", e.expression, e.underlying.Error())
+}

--- a/pkg/input/arm/eval.go
+++ b/pkg/input/arm/eval.go
@@ -1,0 +1,90 @@
+// © 2022-2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arm
+
+import (
+	"strings"
+)
+
+// Makes state available to ARM template function evaluation. It contains
+// references to implementations of functions, and the other fields exist to
+// pass data to certain function impls other than what is already in their args.
+type EvaluationContext struct {
+	discoveredResourceSet map[string]struct{}
+	funcs                 map[string]armFnImpl
+}
+
+func NewEvaluationContext(discoveredResourceSet map[string]struct{}) *EvaluationContext {
+	evalCtx := &EvaluationContext{
+		discoveredResourceSet: discoveredResourceSet,
+		funcs: map[string]armFnImpl{
+			"concat":        concatImpl,
+			"resourceGroup": resourceGroupImpl,
+		},
+	}
+	evalCtx.funcs["resourceId"] = evalCtx.resourceIDImpl
+	return evalCtx
+}
+
+// Detects whether an ARM string is an expression (enclosed by []), and
+// tries to evaluate it if so.
+func (e *EvaluationContext) EvaluateTemplateString(input string) (interface{}, error) {
+	if !isTemplateExpression(input) {
+		return input, nil
+	}
+
+	evaluated, err := e.eval(extractAndEscapeTemplateString(input))
+	if err != nil {
+		if armErr, ok := err.(Error); ok {
+			armErr.expression = input
+			err = armErr
+		}
+	}
+
+	return evaluated, err
+}
+
+func isTemplateExpression(input string) bool {
+	return strings.HasPrefix(input, "[") && strings.HasSuffix(input, "]")
+}
+
+// https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-expressions#escape-characters
+func extractAndEscapeTemplateString(input string) string {
+	// Remove brackets
+	input = input[1:(len(input) - 1)]
+	return strings.ReplaceAll(
+		strings.ReplaceAll(
+			input, "[[", "[",
+		), "]]", "]",
+	)
+}
+
+func (e EvaluationContext) eval(input string) (interface{}, error) {
+	tokens, err := tokenize(input)
+	if err != nil {
+		return nil, err
+	}
+	expr, err := parse(tokens)
+	if err != nil {
+		return nil, err
+	}
+	return e.evalExpr(expr)
+}
+
+func (e EvaluationContext) evalExpr(expr expression) (interface{}, error) {
+	return expr.eval(e)
+}
+
+type armFnImpl func(args ...interface{}) (interface{}, error)

--- a/pkg/input/arm/eval_test.go
+++ b/pkg/input/arm/eval_test.go
@@ -1,0 +1,57 @@
+// © 2022-2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEvalTemplateStrings(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    string
+		expected interface{}
+	}{
+		{
+			name:     "returns inputs that are not ARM expressions",
+			input:    "just a plain string, that is [not] and expression",
+			expected: "just a plain string, that is [not] and expression",
+		},
+		{
+			name:     "replaces escape sequences inside ARM expressions",
+			input:    "['[[string literal in brackets]], ''escaped single quotes''']",
+			expected: "[string literal in brackets], 'escaped single quotes'",
+		},
+		{
+			name:     "concat string literals",
+			input:    "[concat('foo', '-bar')]",
+			expected: "foo-bar",
+		},
+		{
+			name:     "attribute access",
+			input:    "[resourceGroup().location]",
+			expected: "stub-location",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			evalCtx := NewEvaluationContext(nil)
+			val, err := evalCtx.EvaluateTemplateString(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, val)
+		})
+	}
+}

--- a/pkg/input/arm/expressions.go
+++ b/pkg/input/arm/expressions.go
@@ -1,0 +1,70 @@
+// © 2022-2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arm
+
+import (
+	"errors"
+	"fmt"
+)
+
+type expression interface {
+	eval(evalCtx EvaluationContext) (interface{}, error)
+}
+
+type stringLiteralExpr string
+
+func (s stringLiteralExpr) eval(evalCtx EvaluationContext) (interface{}, error) {
+	return string(s), nil
+}
+
+type functionExpr struct {
+	name string
+	args []expression
+}
+
+func (f functionExpr) eval(evalCtx EvaluationContext) (interface{}, error) {
+	impl, ok := evalCtx.funcs[f.name]
+	if !ok {
+		return nil, Error{underlying: fmt.Errorf("unsupported function: %s", f.name), kind: UnsupportedFunction}
+	}
+
+	argVals := make([]interface{}, len(f.args))
+	for i, arg := range f.args {
+		var err error
+		argVals[i], err = arg.eval(evalCtx)
+		if err != nil {
+			return nil, Error{underlying: err, kind: EvalError}
+		}
+	}
+	return impl(argVals...)
+}
+
+type propertyExpr struct {
+	obj      expression
+	property string
+}
+
+func (p propertyExpr) eval(evalCtx EvaluationContext) (interface{}, error) {
+	obj, err := p.obj.eval(evalCtx)
+	if err != nil {
+		return nil, err
+	}
+	objMap, ok := obj.(map[string]interface{})
+	if !ok {
+		return nil, Error{underlying: errors.New("property access can only occur on objects"), kind: EvalError}
+	}
+
+	return objMap[p.property], nil
+}

--- a/pkg/input/arm/functions.go
+++ b/pkg/input/arm/functions.go
@@ -1,0 +1,172 @@
+// © 2022-2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arm
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// Implementations for various ARM template functions
+
+var resourceTypePattern = regexp.MustCompile(`^Microsoft\.\w+[/\w]*$`)
+
+// Note that concat can operate on arrays too, we just haven't implemented
+// support for this yet.
+func concatImpl(args ...interface{}) (interface{}, error) {
+	res := ""
+	for _, arg := range args {
+		argStr, ok := arg.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected argument %#v to be a string", arg)
+		}
+		res += argStr
+	}
+	return res, nil
+}
+
+// Return a stub
+// https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-functions-scope#resourcegroup
+func resourceGroupImpl(args ...interface{}) (interface{}, error) {
+	if len(args) != 0 {
+		return nil, fmt.Errorf("expected zero args to resourceGroup(), got %d", len(args))
+	}
+
+	return map[string]interface{}{
+		"id":         "stub-id",
+		"name":       "stub-name",
+		"type":       "stub-type",
+		"location":   "stub-location",
+		"managedBy":  "stub-managed-by",
+		"tags":       map[string]interface{}{},
+		"properties": map[string]interface{}{},
+	}, nil
+}
+
+// https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-functions-resource#resourceid
+func (e *EvaluationContext) resourceIDImpl(args ...interface{}) (interface{}, error) {
+	strargs, err := assertAllStrings(args...)
+	if err != nil {
+		return nil, err
+	}
+	fqResourceID, err := extractSubscriptionAndResourceGroupIDs(strargs)
+	if err != nil {
+		return nil, err
+	}
+	resourceID, err := mergeResourceTypesAndNames(fqResourceID.resourceType, fqResourceID.resourceNames)
+	if err != nil {
+		return nil, err
+	}
+
+	// Normalize resource IDs to declared/discovered ones in the input, so that
+	// these can be associated with each other by policy queries.
+	if _, ok := e.discoveredResourceSet[resourceID]; ok {
+		return resourceID, nil
+	}
+
+	fullyQualifiedID := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/%s", fqResourceID.subscriptionID, fqResourceID.resourceGroupName, resourceID)
+	return fullyQualifiedID, nil
+}
+
+type fullyQualifiedResourceID struct {
+	subscriptionID    string
+	resourceGroupName string
+	resourceType      string
+	resourceNames     []string
+}
+
+func extractSubscriptionAndResourceGroupIDs(args []string) (fullyQualifiedResourceID, error) {
+	// Fall back on these stubs, extract parameters below if passed
+	subscriptionID := "stub-subscription-id"
+	resourceGroupName := "stub-resource-group-name"
+	var resourceTypeAndNames []string
+
+	foundResourceType := false
+	for i, arg := range args {
+		if resourceTypePattern.MatchString(arg) {
+			foundResourceType = true
+
+			// If the resource type was not the first arg, we can extract
+			// resourceGroupID and possibly also subscriptionID from the front of the
+			// args
+			switch i {
+			case 0:
+				resourceTypeAndNames = args[:]
+				//nolint:gosimple
+				break
+			case 1:
+				resourceGroupName = args[0]
+				resourceTypeAndNames = args[1:]
+				//nolint:gosimple
+				break
+			case 2:
+				subscriptionID = args[0]
+				resourceGroupName = args[1]
+				resourceTypeAndNames = args[2:]
+				//nolint:gosimple
+				break
+			default:
+				return fullyQualifiedResourceID{}, fmt.Errorf("resourceId: expected to find resource type at argument index 0 or 1, found at %d", i)
+			}
+		}
+	}
+	if !foundResourceType {
+		return fullyQualifiedResourceID{}, errors.New("resourceId: found no argument that resembles a resource type")
+	}
+	if len(resourceTypeAndNames) < 2 {
+		return fullyQualifiedResourceID{}, errors.New("resourceId: expected at least a resource type and single resource name to be specified")
+	}
+	return fullyQualifiedResourceID{
+		subscriptionID:    subscriptionID,
+		resourceGroupName: resourceGroupName,
+		resourceType:      resourceTypeAndNames[0],
+		resourceNames:     resourceTypeAndNames[1:],
+	}, nil
+}
+
+// Create Azure-style resource address:
+// (Microsoft.Namespace/Type1/Type2, name1, name2) => Microsoft.Namespace/Type1/name1/Type2/name2
+func mergeResourceTypesAndNames(resourceType string, resourceNames []string) (string, error) {
+	resourceTypeParts := strings.Split(resourceType, "/")
+	if len(resourceTypeParts) < 2 {
+		return "", fmt.Errorf("resourceId: expected at least 2 slash-separated components of resourceType %s", resourceType)
+	}
+	resourceNamespace := resourceTypeParts[0]
+	resourceTypes := resourceTypeParts[1:]
+	if len(resourceTypes) != len(resourceNames) {
+		return "", fmt.Errorf("resourceId: mismatched number of resource types (%d) and names (%d) specified", len(resourceTypes), len(resourceNames))
+	}
+
+	resourceID := ""
+	for i, resourceType := range resourceTypes {
+		resourceName := resourceNames[i]
+		resourceID += fmt.Sprintf("/%s/%s", resourceType, resourceName)
+	}
+	return resourceNamespace + resourceID, nil
+}
+
+func assertAllStrings(args ...interface{}) ([]string, error) {
+	strargs := make([]string, len(args))
+	for i, arg := range args {
+		strarg, ok := arg.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected %v to be a string", arg)
+		}
+		strargs[i] = strarg
+	}
+	return strargs, nil
+}

--- a/pkg/input/arm/functions_test.go
+++ b/pkg/input/arm/functions_test.go
@@ -1,0 +1,67 @@
+// © 2022-2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var evalCtx = NewEvaluationContext(
+	map[string]struct{}{
+		"Microsoft.ServiceBus/namespaces/a-discovered-namespace": {},
+	},
+)
+
+func TestResourceIDImpl(t *testing.T) {
+	for _, tc := range []struct {
+		name           string
+		args           []interface{}
+		expectedOutput string
+	}{
+		{
+			name:           "when a subscription ID, resource group ID, and a single resource type are supplied",
+			args:           []interface{}{"a-subscription-id", "resource-group-id", "Microsoft.ServiceBus/namespaces", "namespace1"},
+			expectedOutput: "/subscriptions/a-subscription-id/resourceGroups/resource-group-id/providers/Microsoft.ServiceBus/namespaces/namespace1",
+		},
+		{
+			name:           "when resource group ID and a single resource type are supplied",
+			args:           []interface{}{"resource-group-id", "Microsoft.ServiceBus/namespaces", "namespace1"},
+			expectedOutput: "/subscriptions/stub-subscription-id/resourceGroups/resource-group-id/providers/Microsoft.ServiceBus/namespaces/namespace1",
+		},
+		{
+			name:           "when only a single resource type is supplied",
+			args:           []interface{}{"Microsoft.ServiceBus/namespaces", "namespace1"},
+			expectedOutput: "/subscriptions/stub-subscription-id/resourceGroups/stub-resource-group-name/providers/Microsoft.ServiceBus/namespaces/namespace1",
+		},
+		{
+			name:           "when multiple resources are supplied",
+			args:           []interface{}{"Microsoft.SQL/servers/databases", "serverName", "databaseName"},
+			expectedOutput: "/subscriptions/stub-subscription-id/resourceGroups/stub-resource-group-name/providers/Microsoft.SQL/servers/serverName/databases/databaseName",
+		},
+		{
+			name:           "when the calculated ID contains a discovered resource, it is normalized to that form",
+			args:           []interface{}{"Microsoft.ServiceBus/namespaces", "a-discovered-namespace"},
+			expectedOutput: "Microsoft.ServiceBus/namespaces/a-discovered-namespace",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := evalCtx.resourceIDImpl(tc.args...)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedOutput, output)
+		})
+	}
+}

--- a/pkg/input/arm/parser.go
+++ b/pkg/input/arm/parser.go
@@ -1,0 +1,144 @@
+// © 2022-2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arm
+
+import (
+	"errors"
+	"fmt"
+)
+
+func parse(tokens []token) (expression, error) {
+	p := &parser{remaining: tokens}
+	return p.parse()
+}
+
+type parser struct {
+	remaining []token
+}
+
+func (p *parser) parse() (expression, error) {
+	tkn, ok := p.pop()
+	if !ok {
+		return nil, newParserError(errors.New("can't build expression from 0 tokens"))
+	}
+
+	// We may need to add support for more types (integer, bool, arrays and
+	// objects) when we add support for more functions.
+	// https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-expressions
+	if strToken, ok := tkn.(stringLiteral); ok {
+		return stringLiteralExpr(strToken), nil
+	}
+
+	// If we reach here, we are building a function expression, because there are
+	// no "direct" identifier dereferences in ARM template expressions. The
+	// identifier is the function name.
+	idToken, ok := tkn.(identifier)
+	if !ok {
+		return nil, newParserError(fmt.Errorf("expected token %#v to be an identifier", tkn))
+	}
+
+	// expect an open paren
+	tkn, ok = p.pop()
+	if !ok {
+		return nil, newParserError(errors.New("expression cannot terminate with an identifier"))
+	}
+	if _, ok := tkn.(openParen); !ok {
+		return nil, newParserError(fmt.Errorf("expected token %#v to be a paren", tkn))
+	}
+	if _, ok := p.peek(); !ok {
+		return nil, newParserError(errors.New("expression cannot terminate with an open paren"))
+	}
+
+	var args []expression
+	for {
+		// In the first iteration, we've just peeked successfully. In all subsequent
+		// iterations, we'd have broken out of the loop if we had exhausted all
+		// tokens.
+		tkn, _ := p.peek()
+		if _, ok := tkn.(closeParen); ok {
+			p.pop() // pop the close paren
+			expr := functionExpr{name: string(idToken), args: args}
+			tkn, ok := p.peek()
+			if !ok {
+				return expr, nil
+			}
+			if _, ok := tkn.(dot); ok {
+				return p.buildPropertyAccessExpression(expr)
+			}
+			return expr, nil
+		}
+
+		// There is a comma between args, so not before the first arg
+		if len(args) > 0 {
+			// We can't reach here if we have exhausted all tokens above
+			tkn, _ := p.peek()
+			if _, ok := tkn.(comma); !ok {
+				return nil, newParserError(fmt.Errorf("expected token %#v to be a comma", tkn))
+			}
+			p.pop() // pop the comma
+		}
+
+		nextArg, err := p.parse()
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, nextArg)
+	}
+}
+
+func (p *parser) buildPropertyAccessExpression(expr expression) (expression, error) {
+	// we only enter this function from parse() if we peeked at a dot, so we know
+	// it gets past here at least once, and so always builds a real property
+	// access expression.
+	tkn, ok := p.peek()
+	if !ok {
+		return expr, nil
+	}
+	if _, ok := tkn.(dot); !ok {
+		return expr, nil
+	}
+
+	p.pop() // pop the dot
+	tkn, ok = p.pop()
+	if !ok {
+		return nil, newParserError(errors.New("expression cannot terminate with a dot"))
+	}
+	nextPropChainElement, ok := tkn.(identifier)
+	if !ok {
+		return nil, newParserError(fmt.Errorf("expected token %#v to be an identifier", tkn))
+	}
+	expr = propertyExpr{obj: expr, property: string(nextPropChainElement)}
+	return p.buildPropertyAccessExpression(expr)
+}
+
+func (p *parser) peek() (token, bool) {
+	if len(p.remaining) == 0 {
+		return nil, false
+	}
+	return p.remaining[0], true
+}
+
+func (p *parser) pop() (token, bool) {
+	if len(p.remaining) == 0 {
+		return nil, false
+	}
+	tkn := p.remaining[0]
+	p.remaining = p.remaining[1:]
+	return tkn, true
+}
+
+func newParserError(underlying error) error {
+	return Error{underlying: underlying, kind: ParserError}
+}

--- a/pkg/input/arm/parser_test.go
+++ b/pkg/input/arm/parser_test.go
@@ -1,0 +1,97 @@
+// © 2022-2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    string
+		expected expression
+	}{
+		{
+			name:     "returns simple expression for a single scalar",
+			input:    "'hi'",
+			expected: stringLiteralExpr("hi"),
+		},
+		{
+			name:     "returns expression for single function call (no args)",
+			input:    "resourceGroup()",
+			expected: functionExpr{name: "resourceGroup"},
+		},
+		{
+			name:  "returns expression for single function call (1 arg)",
+			input: "bork('foo')",
+			expected: functionExpr{
+				name: "bork",
+				args: []expression{stringLiteralExpr("foo")},
+			},
+		},
+		{
+			name:  "returns expression for single function call (2 args)",
+			input: "concat('foo', 'bar')",
+			expected: functionExpr{
+				name: "concat",
+				args: []expression{stringLiteralExpr("foo"), stringLiteralExpr("bar")},
+			},
+		},
+		{
+			name:  "returns expression for nested function calls",
+			input: "concat(resourceGroup(), '-thing')",
+			expected: functionExpr{
+				name: "concat",
+				args: []expression{
+					functionExpr{name: "resourceGroup"},
+					stringLiteralExpr("-thing"),
+				},
+			},
+		},
+		{
+			name:  "returns expression for property access",
+			input: "resourceGroup().location",
+			expected: propertyExpr{
+				obj:      functionExpr{name: "resourceGroup"},
+				property: "location",
+			},
+		},
+		{
+			name:  "returns expression for nested property access",
+			input: "resourceGroup().foo.bar.baz",
+			expected: propertyExpr{
+				obj: propertyExpr{
+					obj: propertyExpr{
+						obj:      functionExpr{name: "resourceGroup"},
+						property: "foo",
+					},
+					property: "bar",
+				},
+				property: "baz",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tokens, err := tokenize(tc.input)
+			require.NoError(t, err)
+			result, err := parse(tokens)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/pkg/input/arm/tokenizer.go
+++ b/pkg/input/arm/tokenizer.go
@@ -1,0 +1,140 @@
+// © 2022-2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arm
+
+import (
+	"errors"
+	"unicode"
+)
+
+func tokenize(input string) ([]token, error) {
+	var tokens []token
+	t := &tokenizer{remaining: []rune(input)}
+	for {
+		tkn, err := t.next()
+		if err != nil {
+			return nil, err
+		}
+		if tkn == nil {
+			return tokens, nil
+		}
+		tokens = append(tokens, tkn)
+	}
+}
+
+type tokenizer struct {
+	remaining []rune
+}
+
+func (t *tokenizer) peek() (rune, bool) {
+	if len(t.remaining) == 0 {
+		return 0, false
+	}
+	return t.remaining[0], true
+}
+
+func (t *tokenizer) pop() (rune, bool) {
+	c, ok := t.peek()
+	if !ok {
+		return c, false
+	}
+	t.remaining = t.remaining[1:]
+	return c, ok
+}
+
+func (t *tokenizer) next() (token, error) {
+	// Discard any whitespace
+	c1, ok := t.pop()
+	for ok && unicode.IsSpace(c1) {
+		c1, ok = t.pop()
+	}
+
+	// End of text
+	if !ok {
+		return nil, nil
+	}
+
+	switch c1 {
+	case '(':
+		return openParen{}, nil
+	case ')':
+		return closeParen{}, nil
+	case ',':
+		return comma{}, nil
+	case '.':
+		return dot{}, nil
+	case '\'':
+		// We are inside a string, parse it completely
+		str := []rune{}
+		for {
+			c, ok := t.pop()
+			if !ok {
+				return nil, newTokenizerError(errors.New("expected ' to end string"))
+			}
+			if c == '\'' {
+				// Could be end of string or an escaped '\', take a peek.
+				c2, ok := t.peek()
+				if ok && c2 == '\'' {
+					t.pop()
+					str = append(str, '\'')
+				} else {
+					return stringLiteral(string(str)), nil
+				}
+			} else {
+				// A normal character inside a string, just add it.
+				str = append(str, c)
+			}
+		}
+	default:
+		// if we reach here, the token is an identifier
+		if validIdentifierStart(c1) {
+			id := []rune{c1}
+			for {
+				// Keep adding valid characters to id while we can
+				c, ok := t.peek()
+				if ok && validIdentifierChar(c) {
+					t.pop()
+					id = append(id, c)
+				} else {
+					return identifier(string(id)), nil
+				}
+			}
+		}
+
+		return nil, newTokenizerError(errors.New("unexpected character"))
+	}
+}
+
+func validIdentifierStart(c rune) bool {
+	return unicode.IsLetter(c)
+}
+
+func validIdentifierChar(c rune) bool {
+	return unicode.IsLetter(c) || unicode.IsDigit(c) || c == '_'
+}
+
+type token interface {
+}
+
+type openParen struct{}
+type closeParen struct{}
+type comma struct{}
+type dot struct{}
+type identifier string
+type stringLiteral string
+
+func newTokenizerError(underlying error) error {
+	return Error{underlying: underlying, kind: TokenizerError}
+}

--- a/pkg/input/arm/tokenizer_test.go
+++ b/pkg/input/arm/tokenizer_test.go
@@ -1,0 +1,98 @@
+// © 2022-2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTokenizesExpressions(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    string
+		expected []token
+	}{
+		{
+			name:  "tokenizes expression containing commas, brackets, and parentheses",
+			input: "someFn(arg1, ARG_2)",
+			expected: []token{
+				identifier("someFn"),
+				openParen{},
+				identifier("arg1"),
+				comma{},
+				identifier("ARG_2"),
+				closeParen{},
+			},
+		},
+		{
+			name:  "tokenizes expression containing variable whitespace",
+			input: "someFn (\t\targ1,      ARG_2)",
+			expected: []token{
+				identifier("someFn"),
+				openParen{},
+				identifier("arg1"),
+				comma{},
+				identifier("ARG_2"),
+				closeParen{},
+			},
+		},
+		{
+			name:  "tokenizes expression containing string literals",
+			input: "someFn('a-string', 'another string')",
+			expected: []token{
+				identifier("someFn"),
+				openParen{},
+				stringLiteral("a-string"),
+				comma{},
+				stringLiteral("another string"),
+				closeParen{},
+			},
+		},
+		{
+			name:  "tokenizes expression containing string literals containing escaped single quotes",
+			input: "'some ''escaped'' ''quotes'''",
+			expected: []token{
+				stringLiteral("some 'escaped' 'quotes'"),
+			},
+		},
+		{
+			name:  "tokenizes expression containing string literals with special characters",
+			input: "'[some]' 'more(special, characters)'",
+			expected: []token{
+				stringLiteral("[some]"),
+				stringLiteral("more(special, characters)"),
+			},
+		},
+		{
+			name:  "tokenizes expression containing property dereferences",
+			input: "resourceGroup().location",
+			expected: []token{
+				identifier("resourceGroup"),
+				openParen{},
+				closeParen{},
+				dot{},
+				identifier("location"),
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			output, err := tokenize(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, output)
+		})
+	}
+}

--- a/pkg/input/golden_test/arm/expressions.json
+++ b/pkg/input/golden_test/arm/expressions.json
@@ -1,0 +1,77 @@
+{
+  "format": "",
+  "format_version": "",
+  "input_type": "arm",
+  "environment_provider": "iac",
+  "meta": {
+    "filepath": "golden_test/arm/expressions/template.json"
+  },
+  "resources": {
+    "Microsoft.Network/virtualNetworks": {
+      "Microsoft.Network/virtualNetworks/VNet1": {
+        "id": "Microsoft.Network/virtualNetworks/VNet1",
+        "resource_type": "Microsoft.Network/virtualNetworks",
+        "namespace": "golden_test/arm/expressions/template.json",
+        "tags": {
+          "Dept": "Finance",
+          "Environment": "Production"
+        },
+        "meta": {},
+        "attributes": {
+          "apiVersion": "2018-10-01",
+          "location": "switzerlandnorth",
+          "properties": {
+            "addressSpace": {
+              "addressPrefixes": [
+                "10.0.0.0/16"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "Microsoft.Network/virtualNetworks/subnets": {
+      "Microsoft.Network/virtualNetworks/VNet1/subnets/Subnet1": {
+        "id": "Microsoft.Network/virtualNetworks/VNet1/subnets/Subnet1",
+        "resource_type": "Microsoft.Network/virtualNetworks/subnets",
+        "namespace": "golden_test/arm/expressions/template.json",
+        "meta": {
+          "arm": {
+            "parent_id": "Microsoft.Network/virtualNetworks/VNet1"
+          }
+        },
+        "attributes": {
+          "_parent_id": "Microsoft.Network/virtualNetworks/VNet1",
+          "apiVersion": "2018-10-01",
+          "dependsOn": [
+            "VNet1"
+          ],
+          "properties": {
+            "addressPrefix": "10.0.0.0/24"
+          }
+        }
+      },
+      "Microsoft.Network/virtualNetworks/VNet1/subnets/Subnet2": {
+        "id": "Microsoft.Network/virtualNetworks/VNet1/subnets/Subnet2",
+        "resource_type": "Microsoft.Network/virtualNetworks/subnets",
+        "namespace": "golden_test/arm/expressions/template.json",
+        "meta": {
+          "arm": {
+            "parent_id": "Microsoft.Network/virtualNetworks/VNet1"
+          }
+        },
+        "attributes": {
+          "_parent_id": "Microsoft.Network/virtualNetworks/VNet1",
+          "apiVersion": "2018-10-01",
+          "dependsOn": [
+            "VNet1"
+          ],
+          "properties": {
+            "addressPrefix": "10.0.1.0/24",
+            "brokenExpression": "[unknownFunction()]"
+          }
+        }
+      }
+    }
+  }
+}

--- a/pkg/input/golden_test/arm/expressions/template.json
+++ b/pkg/input/golden_test/arm/expressions/template.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "resources": [
+    {
+      "type": "Microsoft.Network/virtualNetworks",
+      "apiVersion": "2018-10-01",
+      "name": "VNet1",
+      "location": "[concat('switzerland', 'north')]",
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "10.0.0.0/16"
+          ]
+        }
+      },
+      "tags": {
+        "Dept": "Finance",
+        "Environment": "Production"
+      },
+      "resources": [
+        {
+          "type": "subnets",
+          "apiVersion": "2018-10-01",
+          "name": "Subnet1",
+          "dependsOn": [
+            "VNet1"
+          ],
+          "properties": {
+            "addressPrefix": "10.0.0.0/24"
+          }
+        }
+      ]
+    },
+    {
+      "type": "Microsoft.Network/virtualNetworks/subnets",
+      "apiVersion": "2018-10-01",
+      "name": "VNet1/Subnet2",
+      "dependsOn": [
+        "VNet1"
+      ],
+      "properties": {
+        "addressPrefix": "10.0.1.0/24",
+        "brokenExpression": "[unknownFunction()]"
+      }
+    }
+  ]
+}

--- a/pkg/input/golden_test/arm/refs-01.json
+++ b/pkg/input/golden_test/arm/refs-01.json
@@ -15,7 +15,7 @@
         "meta": {},
         "attributes": {
           "apiVersion": "2021-02-01",
-          "location": "[resourceGroup().location]",
+          "location": "stub-location",
           "properties": {},
           "sku": {
             "name": "B1",
@@ -39,7 +39,7 @@
           "identity": {
             "type": "None"
           },
-          "location": "[resourceGroup().location]",
+          "location": "stub-location",
           "properties": {
             "serverFarmId": "Microsoft.Web/serverfarms/appServicePlanPortal"
           }
@@ -55,9 +55,29 @@
           "dependsOn": [
             "Microsoft.Web/serverfarms/appServicePlanPortal"
           ],
-          "location": "[resourceGroup().location]",
+          "location": "stub-location",
           "properties": {
             "serverFarmId": "Microsoft.Web/serverfarms/appServicePlanPortal"
+          }
+        }
+      },
+      "Microsoft.Web/sites/referencesExternalResources": {
+        "id": "Microsoft.Web/sites/referencesExternalResources",
+        "resource_type": "Microsoft.Web/sites",
+        "namespace": "golden_test/arm/refs-01/template.json",
+        "meta": {},
+        "attributes": {
+          "apiVersion": "2021-02-01",
+          "dependsOn": [
+            "/subscriptions/some-subscription/resourceGroups/some-resource-group/providers/Microsoft.Web/serverfarms/anotherServerFarm1",
+            "/subscriptions/stub-subscription-id/resourceGroups/some-resource-group/providers/Microsoft.Web/serverfarms/anotherServerFarm2"
+          ],
+          "identity": {
+            "type": "SystemAssigned"
+          },
+          "location": "stub-location",
+          "properties": {
+            "serverFarmId": "/subscriptions/stub-subscription-id/resourceGroups/stub-resource-group-name/providers/Microsoft.Web/serverfarms/anotherServerFarm3"
           }
         }
       },
@@ -74,7 +94,7 @@
           "identity": {
             "type": "SystemAssigned"
           },
-          "location": "[resourceGroup().location]",
+          "location": "stub-location",
           "properties": {
             "serverFarmId": "Microsoft.Web/serverfarms/appServicePlanPortal"
           }

--- a/pkg/input/golden_test/arm/refs-01/template.json
+++ b/pkg/input/golden_test/arm/refs-01/template.json
@@ -54,6 +54,22 @@
       "properties": {
         "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', 'appServicePlanPortal')]"
       }
+    },
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2021-02-01",
+      "name": "referencesExternalResources",
+      "location": "[resourceGroup().location]",
+      "identity": {
+        "type": "SystemAssigned"
+      },
+      "dependsOn": [
+        "[resourceId('some-subscription', 'some-resource-group', 'Microsoft.Web/serverfarms', 'anotherServerFarm1')]",
+        "[resourceId('some-resource-group', 'Microsoft.Web/serverfarms', 'anotherServerFarm2')]"
+      ],
+      "properties": {
+        "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', 'anotherServerFarm3')]"
+      }
     }
   ]
 }


### PR DESCRIPTION


**feat: evaluate ARM template expressions**

Detect whether Azure resource manager template string fields are
expressions (https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-expressions)
and try to evaluate them if so.

* If evaluation fails, fall back on treating the expression as a plain
  string, and return the evaluation failure as a non-fatal error.
* Initial support for a few functions, including resourceId, which was
  previously treated as a special case with some support before this
  commit. This commit aims to preserve its behavior with regard to
  trying to detect when a return value of resourceId() matches another
  resource in the input, and "normalizing" them to be equal.



**fix: return non-fatal ARM errors**

Remove a call-order dependency between armConfiguration's ToState() and
Errors() methods by eagerly processing the input at load time, then
returning precomputed results from each method. Errors() is then
guaranteed to contain all errors from ARM expression evaluation even
before ToState() is called.

---

https://snyksec.atlassian.net/browse/CLOUD-1573

