### PR TITLE
[CLOUD-1573] feat: initial support for ARM template variables

### DIFF
--- a/changes/unreleased/Added-20230628-114847.yaml
+++ b/changes/unreleased/Added-20230628-114847.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Initial support for ARM template variables
+time: 2023-06-28T11:48:47.606077+01:00

--- a/pkg/input/arm/README.md
+++ b/pkg/input/arm/README.md
@@ -1,0 +1,20 @@
+# `arm` package
+
+`policy-engine` has some support for evaluating [ARM template
+expressions](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/syntax),
+but there are some known limitations:
+
+* Not all functions are supported. The source of truth for function support is
+  [the keys of `EvaluationContext.funcs` set in `NewEvaluationContext()` in `eval.go`](./eval.go).
+   * Not all types are supported. These will be added as we add support for
+     functions that make use of these types.
+* Template expressions in resource-identifying fields (type, name, and tags) are
+  not evaluated.
+* Template expressions in variables definitions are not evaluated.
+* Support for functions that require "deployment context" such as
+  `resourceGroup()` and `resourceId()` is limited by definition: `policy-engine`
+  returns stubs for return value fields that it can't know about.
+
+Failures in expression evaluation are non-fatal, but may lead to false
+positives/negatives in policy evaluation if the result of the expression would
+have been significant to the policy.

--- a/pkg/input/arm/eval_test.go
+++ b/pkg/input/arm/eval_test.go
@@ -48,7 +48,7 @@ func TestEvalTemplateStrings(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			evalCtx := NewEvaluationContext(nil)
+			evalCtx := NewEvaluationContext(nil, nil)
 			val, err := evalCtx.EvaluateTemplateString(tc.input)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, val)

--- a/pkg/input/arm/functions.go
+++ b/pkg/input/arm/functions.go
@@ -170,3 +170,19 @@ func assertAllStrings(args ...interface{}) ([]string, error) {
 	}
 	return strargs, nil
 }
+
+func (e *EvaluationContext) variablesImpl(args ...interface{}) (interface{}, error) {
+	strargs, err := assertAllStrings(args...)
+	if err != nil {
+		return nil, err
+	}
+	if len(strargs) != 1 {
+		return nil, fmt.Errorf("variables: expected 1 arg, got %d", len(strargs))
+	}
+	key := strargs[0]
+	val, ok := e.variables[key]
+	if !ok {
+		return nil, fmt.Errorf("no variable found for key %s", key)
+	}
+	return val, nil
+}

--- a/pkg/input/arm/functions_test.go
+++ b/pkg/input/arm/functions_test.go
@@ -24,6 +24,7 @@ var evalCtx = NewEvaluationContext(
 	map[string]struct{}{
 		"Microsoft.ServiceBus/namespaces/a-discovered-namespace": {},
 	},
+	nil,
 )
 
 func TestResourceIDImpl(t *testing.T) {

--- a/pkg/input/arm/parser.go
+++ b/pkg/input/arm/parser.go
@@ -36,6 +36,10 @@ func (p *parser) parse() (expression, error) {
 
 	// We may need to add support for more types (integer, bool, arrays and
 	// objects) when we add support for more functions.
+	//
+	// When adding more types, please remember to update support for these types
+	// in variables. See pkg/input/arm.go.
+	//
 	// https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-expressions
 	if strToken, ok := tkn.(stringLiteral); ok {
 		return stringLiteralExpr(strToken), nil

--- a/pkg/input/golden_test/arm/variables.json
+++ b/pkg/input/golden_test/arm/variables.json
@@ -1,0 +1,35 @@
+{
+  "format": "",
+  "format_version": "",
+  "input_type": "arm",
+  "environment_provider": "iac",
+  "meta": {
+    "filepath": "golden_test/arm/variables/template.json"
+  },
+  "resources": {
+    "Microsoft.AppConfiguration/configurationStores": {
+      "Microsoft.AppConfiguration/configurationStores/arm-608-denied": {
+        "id": "Microsoft.AppConfiguration/configurationStores/arm-608-denied",
+        "resource_type": "Microsoft.AppConfiguration/configurationStores",
+        "namespace": "golden_test/arm/variables/template.json",
+        "meta": {},
+        "attributes": {
+          "apiVersion": "2021-03-01-preview",
+          "location": "West Europe",
+          "properties": {
+            "arrayVarNotCurrentlySupported": "[variables('arrayVar')]",
+            "expressionEvalNotCurrentlySupported": "[variables('expressionVarStringResult')]",
+            "intVarNotCurrentlySupported": "[variables('intVar')]",
+            "objectVarNotCurrentlySupported": "[variables('objectVar')]",
+            "publicNetworkAccess": "Enabled",
+            "stringVarAccess": "a string variable",
+            "unknownVarAcesss": "[variables('unknown')]"
+          },
+          "sku": {
+            "name": "Free"
+          }
+        }
+      }
+    }
+  }
+}

--- a/pkg/input/golden_test/arm/variables/template.json
+++ b/pkg/input/golden_test/arm/variables/template.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {},
+  "variables": {
+    "stringVar": "a string variable",
+    "intVar": 4,
+    "arrayVar": [
+      1,
+      2,
+      3,
+      4
+    ],
+    "objectVar": {
+      "property1": "value1",
+      "property2": "value2"
+    },
+    "expressionVarStringResult": "[concat(variables('stringVar'), '-addtovar') ]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.AppConfiguration/configurationStores",
+      "apiVersion": "2021-03-01-preview",
+      "name": "arm-608-denied",
+      "location": "West Europe",
+      "sku": {
+        "name": "Free"
+      },
+      "properties": {
+        "publicNetworkAccess": "Enabled",
+        "stringVarAccess": "[variables('stringVar')]",
+        "intVarNotCurrentlySupported": "[variables('intVar')]",
+        "arrayVarNotCurrentlySupported": "[variables('arrayVar')]",
+        "objectVarNotCurrentlySupported": "[variables('objectVar')]",
+        "unknownVarAcesss": "[variables('unknown')]",
+        "expressionEvalNotCurrentlySupported": "[variables('expressionVarStringResult')]"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
For now, only strings are supported. Other types can be added in the future when we add parser support for these types, which itself would be motivated by function support that uses those types.

Add a readme to the ARM package explaining some known limitations.

https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/variables