### PR TITLE
chore: refactor EvaluationContext

### DIFF
--- a/changes/unreleased/Changed-20230628-174616.yaml
+++ b/changes/unreleased/Changed-20230628-174616.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'refactor: arm EvaluationContext'
+time: 2023-06-28T17:46:16.926549028+02:00

--- a/pkg/input/arm.go
+++ b/pkg/input/arm.go
@@ -179,7 +179,7 @@ func (l *armConfiguration) process() {
 		evalCtx: &arm.EvaluationContext{
 			DiscoveredResourceSet: resourceSet,
 			Variables:             l.variables,
-			BuiltinFunctions:      arm.BuiltinFunctions(),
+			Functions:             arm.BuiltinFunctions(),
 		},
 	}
 

--- a/pkg/input/arm.go
+++ b/pkg/input/arm.go
@@ -176,7 +176,11 @@ func (l *armConfiguration) process() {
 		resourceSet[id] = struct{}{}
 	}
 	exprEvaluator := expressionEvaluator{
-		evalCtx: arm.NewEvaluationContext(resourceSet, l.variables),
+		evalCtx: &arm.EvaluationContext{
+			DiscoveredResourceSet: resourceSet,
+			Variables:             l.variables,
+			BuiltinFunctions:      arm.BuiltinFunctions(),
+		},
 	}
 
 	// Process resources

--- a/pkg/input/arm/eval.go
+++ b/pkg/input/arm/eval.go
@@ -24,7 +24,7 @@ import (
 type EvaluationContext struct {
 	DiscoveredResourceSet map[string]struct{}
 	Variables             map[string]interface{}
-	BuiltinFunctions      map[string]Function
+	Functions             map[string]Function
 }
 
 type Function func(e *EvaluationContext, args ...interface{}) (interface{}, error)

--- a/pkg/input/arm/eval_test.go
+++ b/pkg/input/arm/eval_test.go
@@ -48,7 +48,7 @@ func TestEvalTemplateStrings(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			evalCtx := &EvaluationContext{BuiltinFunctions: BuiltinFunctions()}
+			evalCtx := &EvaluationContext{Functions: BuiltinFunctions()}
 			val, err := evalCtx.EvaluateTemplateString(tc.input)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, val)

--- a/pkg/input/arm/eval_test.go
+++ b/pkg/input/arm/eval_test.go
@@ -48,7 +48,7 @@ func TestEvalTemplateStrings(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			evalCtx := NewEvaluationContext(nil, nil)
+			evalCtx := &EvaluationContext{BuiltinFunctions: BuiltinFunctions()}
 			val, err := evalCtx.EvaluateTemplateString(tc.input)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, val)

--- a/pkg/input/arm/expressions.go
+++ b/pkg/input/arm/expressions.go
@@ -35,7 +35,7 @@ type functionExpr struct {
 }
 
 func (f functionExpr) eval(evalCtx *EvaluationContext) (interface{}, error) {
-	impl, ok := evalCtx.BuiltinFunctions[f.name]
+	impl, ok := evalCtx.Functions[f.name]
 	if !ok {
 		return nil, Error{underlying: fmt.Errorf("unsupported function: %s", f.name), kind: UnsupportedFunction}
 	}

--- a/pkg/input/arm/expressions.go
+++ b/pkg/input/arm/expressions.go
@@ -20,12 +20,12 @@ import (
 )
 
 type expression interface {
-	eval(evalCtx EvaluationContext) (interface{}, error)
+	eval(evalCtx *EvaluationContext) (interface{}, error)
 }
 
 type stringLiteralExpr string
 
-func (s stringLiteralExpr) eval(evalCtx EvaluationContext) (interface{}, error) {
+func (s stringLiteralExpr) eval(evalCtx *EvaluationContext) (interface{}, error) {
 	return string(s), nil
 }
 
@@ -34,8 +34,8 @@ type functionExpr struct {
 	args []expression
 }
 
-func (f functionExpr) eval(evalCtx EvaluationContext) (interface{}, error) {
-	impl, ok := evalCtx.funcs[f.name]
+func (f functionExpr) eval(evalCtx *EvaluationContext) (interface{}, error) {
+	impl, ok := evalCtx.BuiltinFunctions[f.name]
 	if !ok {
 		return nil, Error{underlying: fmt.Errorf("unsupported function: %s", f.name), kind: UnsupportedFunction}
 	}
@@ -48,7 +48,7 @@ func (f functionExpr) eval(evalCtx EvaluationContext) (interface{}, error) {
 			return nil, Error{underlying: err, kind: EvalError}
 		}
 	}
-	return impl(argVals...)
+	return impl(evalCtx, argVals...)
 }
 
 type propertyExpr struct {
@@ -56,7 +56,7 @@ type propertyExpr struct {
 	property string
 }
 
-func (p propertyExpr) eval(evalCtx EvaluationContext) (interface{}, error) {
+func (p propertyExpr) eval(evalCtx *EvaluationContext) (interface{}, error) {
 	obj, err := p.obj.eval(evalCtx)
 	if err != nil {
 		return nil, err

--- a/pkg/input/arm/functions.go
+++ b/pkg/input/arm/functions.go
@@ -27,7 +27,7 @@ var resourceTypePattern = regexp.MustCompile(`^Microsoft\.\w+[/\w]*$`)
 
 // Note that concat can operate on arrays too, we just haven't implemented
 // support for this yet.
-func concatImpl(args ...interface{}) (interface{}, error) {
+func concatImpl(e *EvaluationContext, args ...interface{}) (interface{}, error) {
 	res := ""
 	for _, arg := range args {
 		argStr, ok := arg.(string)
@@ -41,7 +41,7 @@ func concatImpl(args ...interface{}) (interface{}, error) {
 
 // Return a stub
 // https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-functions-scope#resourcegroup
-func resourceGroupImpl(args ...interface{}) (interface{}, error) {
+func resourceGroupImpl(e *EvaluationContext, args ...interface{}) (interface{}, error) {
 	if len(args) != 0 {
 		return nil, fmt.Errorf("expected zero args to resourceGroup(), got %d", len(args))
 	}
@@ -58,7 +58,7 @@ func resourceGroupImpl(args ...interface{}) (interface{}, error) {
 }
 
 // https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-functions-resource#resourceid
-func (e *EvaluationContext) resourceIDImpl(args ...interface{}) (interface{}, error) {
+func resourceIDImpl(e *EvaluationContext, args ...interface{}) (interface{}, error) {
 	strargs, err := assertAllStrings(args...)
 	if err != nil {
 		return nil, err
@@ -74,7 +74,7 @@ func (e *EvaluationContext) resourceIDImpl(args ...interface{}) (interface{}, er
 
 	// Normalize resource IDs to declared/discovered ones in the input, so that
 	// these can be associated with each other by policy queries.
-	if _, ok := e.discoveredResourceSet[resourceID]; ok {
+	if _, ok := e.DiscoveredResourceSet[resourceID]; ok {
 		return resourceID, nil
 	}
 
@@ -171,7 +171,7 @@ func assertAllStrings(args ...interface{}) ([]string, error) {
 	return strargs, nil
 }
 
-func (e *EvaluationContext) variablesImpl(args ...interface{}) (interface{}, error) {
+func variablesImpl(e *EvaluationContext, args ...interface{}) (interface{}, error) {
 	strargs, err := assertAllStrings(args...)
 	if err != nil {
 		return nil, err
@@ -180,7 +180,7 @@ func (e *EvaluationContext) variablesImpl(args ...interface{}) (interface{}, err
 		return nil, fmt.Errorf("variables: expected 1 arg, got %d", len(strargs))
 	}
 	key := strargs[0]
-	val, ok := e.variables[key]
+	val, ok := e.Variables[key]
 	if !ok {
 		return nil, fmt.Errorf("no variable found for key %s", key)
 	}

--- a/pkg/input/arm/functions_test.go
+++ b/pkg/input/arm/functions_test.go
@@ -24,7 +24,7 @@ var evalCtx = &EvaluationContext{
 	DiscoveredResourceSet: map[string]struct{}{
 		"Microsoft.ServiceBus/namespaces/a-discovered-namespace": {},
 	},
-	BuiltinFunctions: BuiltinFunctions(),
+	Functions: BuiltinFunctions(),
 }
 
 func TestResourceIDImpl(t *testing.T) {

--- a/pkg/input/arm/functions_test.go
+++ b/pkg/input/arm/functions_test.go
@@ -20,12 +20,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var evalCtx = NewEvaluationContext(
-	map[string]struct{}{
+var evalCtx = &EvaluationContext{
+	DiscoveredResourceSet: map[string]struct{}{
 		"Microsoft.ServiceBus/namespaces/a-discovered-namespace": {},
 	},
-	nil,
-)
+	BuiltinFunctions: BuiltinFunctions(),
+}
 
 func TestResourceIDImpl(t *testing.T) {
 	for _, tc := range []struct {
@@ -60,7 +60,7 @@ func TestResourceIDImpl(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			output, err := evalCtx.resourceIDImpl(tc.args...)
+			output, err := resourceIDImpl(evalCtx, tc.args...)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedOutput, output)
 		})


### PR DESCRIPTION
 -  I wanted to make NewEvaluationContext take an options struct, so we could more easily add parameters without breaking call sites.  Since this options struct ended up being the context itself, I removed `NewEvaluationContext` for now...

 -  I tweaked the interface of functions, so all functions have the same shape.

 -  Adjusted the visibility of Function/EvaluationContext so in principle callers can add their own functions