### PR TITLE
feat: eval ARM exprs during resource discovery (CLOUD-1648)

### DIFF
--- a/changes/unreleased/Added-20230725-070509.yaml
+++ b/changes/unreleased/Added-20230725-070509.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: evaluate ARM template expressions during resource discovery (CLOUD-1648)
+time: 2023-07-25T07:05:09.624192+02:00

--- a/pkg/input/arm/README.md
+++ b/pkg/input/arm/README.md
@@ -4,12 +4,15 @@
 expressions](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/syntax),
 but there are some known limitations:
 
-* Not all functions are supported. The source of truth for function support is
-  [the keys of `EvaluationContext.funcs` set in `NewEvaluationContext()` in `eval.go`](./eval.go).
-   * Not all types are supported. These will be added as we add support for
-     functions that make use of these types.
-* Template expressions in resource-identifying fields (type, name, and tags) are
-  not evaluated.
+* Not all functions are supported.
+  The source of truth for function support is [builtins.go](./builtins.go).
+  * During resource discovery (the phase in which we figure out the names and
+    types of resources), we support the functions in
+    `DiscoveryBuiltinFunctions()`.
+  * During resource processing, we additionally support those in
+    `AllBuiltinFunctions()`.
+  * Not all types are supported. These will be added as we add support for
+    functions that make use of these types.
 * Template expressions in variables definitions are not evaluated.
 * Support for functions that require "deployment context" such as
   `resourceGroup()` and `resourceId()` is limited by definition: `policy-engine`

--- a/pkg/input/arm/builtins.go
+++ b/pkg/input/arm/builtins.go
@@ -1,0 +1,44 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package arm
+
+// DiscoveryBuiltinFunctions returns the functions available during the
+// discovery phase.  Functions that retrieve information about resources will
+// not yet be available.
+func DiscoveryBuiltinFunctions(
+	variables map[string]interface{},
+) map[string]Function {
+	return map[string]Function{
+		"base64":          oneStringArg(base64Impl),
+		"base64ToString":  oneStringArg(base64ToStringImpl),
+		"concat":          concatImpl,
+		"dataUri":         oneStringArg(dataURIImpl),
+		"dataUriToString": oneStringArg(dataURIToStringImpl),
+		"first":           oneStringArg(firstImpl),
+		"resourceGroup":   resourceGroupImpl,
+		"variables":       variablesImpl(variables),
+	}
+}
+
+// AllBuiltinFunctions returns all builtin functions available.  This includes
+// DiscoveryBuiltinFunctions().
+func AllBuiltinFunctions(
+	variables map[string]interface{},
+	discoveredResourceSet map[string]struct{},
+) map[string]Function {
+	funcs := DiscoveryBuiltinFunctions(variables)
+	funcs["resourceId"] = resourceIDImpl(discoveredResourceSet)
+	return funcs
+}

--- a/pkg/input/arm/eval.go
+++ b/pkg/input/arm/eval.go
@@ -22,26 +22,10 @@ import (
 // references to implementations of functions, and the other fields exist to
 // pass data to certain function impls other than what is already in their args.
 type EvaluationContext struct {
-	DiscoveredResourceSet map[string]struct{}
-	Variables             map[string]interface{}
-	Functions             map[string]Function
+	Functions map[string]Function
 }
 
-type Function func(e *EvaluationContext, args ...interface{}) (interface{}, error)
-
-func BuiltinFunctions() map[string]Function {
-	return map[string]Function{
-		"base64":          oneStringArg(base64Impl),
-		"base64ToString":  oneStringArg(base64ToStringImpl),
-		"concat":          concatImpl,
-		"dataUri":         oneStringArg(dataURIImpl),
-		"dataUriToString": oneStringArg(dataURIToStringImpl),
-		"first":           oneStringArg(firstImpl),
-		"resourceGroup":   resourceGroupImpl,
-		"resourceId":      resourceIDImpl,
-		"variables":       variablesImpl,
-	}
-}
+type Function func(args ...interface{}) (interface{}, error)
 
 // Detects whether an ARM string is an expression (enclosed by []), and
 // tries to evaluate it if so.

--- a/pkg/input/arm/eval_test.go
+++ b/pkg/input/arm/eval_test.go
@@ -48,7 +48,7 @@ func TestEvalTemplateStrings(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			evalCtx := &EvaluationContext{Functions: BuiltinFunctions()}
+			evalCtx := &EvaluationContext{Functions: DiscoveryBuiltinFunctions(nil)}
 			val, err := evalCtx.EvaluateTemplateString(tc.input)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, val)

--- a/pkg/input/arm/expressions.go
+++ b/pkg/input/arm/expressions.go
@@ -48,7 +48,7 @@ func (f functionExpr) eval(evalCtx *EvaluationContext) (interface{}, error) {
 			return nil, Error{underlying: err, kind: EvalError}
 		}
 	}
-	return impl(evalCtx, argVals...)
+	return impl(argVals...)
 }
 
 type propertyExpr struct {

--- a/pkg/input/arm/functions_deployment.go
+++ b/pkg/input/arm/functions_deployment.go
@@ -16,18 +16,20 @@ package arm
 
 import "fmt"
 
-func variablesImpl(e *EvaluationContext, args ...interface{}) (interface{}, error) {
-	strargs, err := assertAllType[string](args...)
-	if err != nil {
-		return nil, err
+func variablesImpl(variables map[string]interface{}) Function {
+	return func(args ...interface{}) (interface{}, error) {
+		strargs, err := assertAllType[string](args...)
+		if err != nil {
+			return nil, err
+		}
+		if len(strargs) != 1 {
+			return nil, fmt.Errorf("variables: expected 1 arg, got %d", len(strargs))
+		}
+		key := strargs[0]
+		val, ok := variables[key]
+		if !ok {
+			return nil, fmt.Errorf("no variable found for key %s", key)
+		}
+		return val, nil
 	}
-	if len(strargs) != 1 {
-		return nil, fmt.Errorf("variables: expected 1 arg, got %d", len(strargs))
-	}
-	key := strargs[0]
-	val, ok := e.Variables[key]
-	if !ok {
-		return nil, fmt.Errorf("no variable found for key %s", key)
-	}
-	return val, nil
 }

--- a/pkg/input/arm/functions_resource_test.go
+++ b/pkg/input/arm/functions_resource_test.go
@@ -20,14 +20,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var evalCtx = &EvaluationContext{
-	DiscoveredResourceSet: map[string]struct{}{
-		"Microsoft.ServiceBus/namespaces/a-discovered-namespace": {},
-	},
-	Functions: BuiltinFunctions(),
-}
-
 func TestResourceIDImpl(t *testing.T) {
+	var resourceID Function = resourceIDImpl(
+		map[string]struct{}{
+			"Microsoft.ServiceBus/namespaces/a-discovered-namespace": {},
+		},
+	)
+
 	for _, tc := range []struct {
 		name           string
 		args           []interface{}
@@ -60,7 +59,7 @@ func TestResourceIDImpl(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			output, err := resourceIDImpl(evalCtx, tc.args...)
+			output, err := resourceID(tc.args...)
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedOutput, output)
 		})

--- a/pkg/input/arm/functions_scope.go
+++ b/pkg/input/arm/functions_scope.go
@@ -18,7 +18,7 @@ import "fmt"
 
 // Return a stub
 // https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-functions-scope#resourcegroup
-func resourceGroupImpl(e *EvaluationContext, args ...interface{}) (interface{}, error) {
+func resourceGroupImpl(args ...interface{}) (interface{}, error) {
 	if len(args) != 0 {
 		return nil, fmt.Errorf("expected zero args to resourceGroup(), got %d", len(args))
 	}

--- a/pkg/input/arm/functions_string.go
+++ b/pkg/input/arm/functions_string.go
@@ -24,7 +24,7 @@ import (
 // Functions from https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-functions-string#base64
 
 func oneStringArg(f func(string) (interface{}, error)) Function {
-	return func(e *EvaluationContext, args ...interface{}) (interface{}, error) {
+	return func(args ...interface{}) (interface{}, error) {
 		strargs, err := assertAllType[string](args...)
 		if err != nil {
 			return nil, err
@@ -53,7 +53,7 @@ func base64ToStringImpl(arg string) (interface{}, error) {
 
 // TODO concat can operate on arrays too, we just haven't implemented support
 // for this yet.
-func concatImpl(e *EvaluationContext, args ...interface{}) (interface{}, error) {
+func concatImpl(args ...interface{}) (interface{}, error) {
 	res := ""
 	for _, arg := range args {
 		argStr, ok := arg.(string)

--- a/pkg/input/arm/functions_string_test.go
+++ b/pkg/input/arm/functions_string_test.go
@@ -33,7 +33,7 @@ func TestBase64ToString(t *testing.T) {
 }
 
 func TestConcat(t *testing.T) {
-	res, err := concatImpl(nil, "foo", "bar")
+	res, err := concatImpl("foo", "bar")
 	require.NoError(t, err)
 	require.Equal(t, "foobar", res)
 }

--- a/pkg/input/golden_test/arm/name-concat.json
+++ b/pkg/input/golden_test/arm/name-concat.json
@@ -1,0 +1,33 @@
+{
+  "format": "",
+  "format_version": "",
+  "input_type": "arm",
+  "environment_provider": "iac",
+  "meta": {
+    "filepath": "golden_test/arm/name-concat/template.json"
+  },
+  "resources": {
+    "Microsoft.Network/virtualNetworks": {
+      "Microsoft.Network/virtualNetworks/VNet1": {
+        "id": "Microsoft.Network/virtualNetworks/VNet1",
+        "resource_type": "Microsoft.Network/virtualNetworks",
+        "namespace": "golden_test/arm/name-concat/template.json",
+        "tags": {
+          "environment": "staging"
+        },
+        "meta": {},
+        "attributes": {
+          "apiVersion": "2018-10-01",
+          "location": "switzerlandnorth",
+          "properties": {
+            "addressSpace": {
+              "addressPrefixes": [
+                "10.0.0.0/16"
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/pkg/input/golden_test/arm/name-concat/template.json
+++ b/pkg/input/golden_test/arm/name-concat/template.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "variables": {
+    "environment": "staging"
+  },
+  "resources": [
+    {
+      "type": "[concat('Microsoft.Network/', 'virtualNetworks')]",
+      "apiVersion": "2018-10-01",
+      "name": "[concat('VNet', '1')]",
+      "location": "switzerlandnorth",
+      "tags": {
+        "environment": "[variables('environment')]"
+      },
+      "properties": {
+        "addressSpace": {
+          "addressPrefixes": [
+            "10.0.0.0/16"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/pkg/interfacetricks/copy.go
+++ b/pkg/interfacetricks/copy.go
@@ -18,11 +18,7 @@ package interfacetricks
 func Copy(value interface{}) interface{} {
 	switch v := value.(type) {
 	case map[string]interface{}:
-		obj := make(map[string]interface{}, len(v))
-		for k, attr := range v {
-			obj[k] = Copy(attr)
-		}
-		return obj
+		return CopyObject(v)
 	case []interface{}:
 		arr := make([]interface{}, len(v))
 		for i, attr := range v {
@@ -32,4 +28,13 @@ func Copy(value interface{}) interface{} {
 	default:
 		return v
 	}
+}
+
+// Utility so we don't need to cast.
+func CopyObject(in map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(in))
+	for k, attr := range in {
+		out[k] = Copy(attr)
+	}
+	return out
 }

--- a/pkg/interfacetricks/extract.go
+++ b/pkg/interfacetricks/extract.go
@@ -1,0 +1,191 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interfacetricks
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type ExtractError struct {
+	SrcPath []interface{}
+	SrcType reflect.Type
+	DstType reflect.Type
+}
+
+func (e ExtractError) Error() string {
+	pieces := []string{}
+	for _, piece := range e.SrcPath {
+		switch v := piece.(type) {
+		case int:
+			pieces = append(pieces, fmt.Sprintf("%d", v))
+		case string:
+			pieces = append(pieces, v)
+		default:
+			pieces = append(pieces, fmt.Sprintf("%v", v))
+		}
+	}
+
+	src := "nil"
+	if e.SrcType != nil {
+		src = e.SrcType.String()
+	}
+	dst := "nil"
+	if e.DstType != nil {
+		dst = e.DstType.String()
+	}
+
+	return fmt.Sprintf(
+		"extract type mismatch at %s: could not map source %s to destination %s",
+		strings.Join(pieces, "/"),
+		src,
+		dst,
+	)
+}
+
+// Extract "deserializes" an interface into a target destination, using the
+// "encoding/json" conventions.
+//
+// No actual serialization happens, which means we can avoid a lot of string
+// copies.
+//
+// The extraction will try to continue even when errors are encountered and
+// return detailed error information for each problem.
+func Extract(src interface{}, dst interface{}) []error {
+	return extract([]interface{}{}, src, reflect.ValueOf(dst))
+}
+
+// NOTE: This code is based on pkg/rego/bind.go, and updates may need to go
+// there as well.
+func extract(path []interface{}, src interface{}, dst reflect.Value) (errs []error) {
+	ty := dst.Type()
+	switch ty.Kind() {
+	case reflect.Pointer:
+		return extract(path, src, dst.Elem())
+	case reflect.Struct:
+		if srcObject, ok := src.(map[string]interface{}); ok {
+			for i := 0; i < ty.NumField(); i++ {
+				field := ty.Field(i)
+				goFieldVal := dst.Field(i)
+				goFieldVal.Set(reflect.Zero(field.Type)) // Set to zero/nil
+				if jsonFieldName, ok := getJsonFieldName(field); ok {
+					if srcFieldVal, ok := srcObject[jsonFieldName]; ok {
+						// Initialize if pointer
+						if field.Type.Kind() == reflect.Pointer {
+							goFieldVal.Set(reflect.New(field.Type.Elem()))
+						}
+
+						path = append(path, jsonFieldName)
+						errs = append(errs, extract(path, srcFieldVal, goFieldVal)...)
+						path = path[:len(path)-1]
+					}
+				} else {
+				}
+			}
+			return
+		}
+	case reflect.Slice:
+		if srcArray, ok := src.([]interface{}); ok && dst.CanSet() {
+			dst.Set(reflect.MakeSlice(ty, len(srcArray), len(srcArray)))
+			for i := 0; i < len(srcArray); i++ {
+				path = append(path, i)
+				errs = append(errs, extract(path, srcArray[i], dst.Index(i))...)
+				path = path[:len(path)-1]
+			}
+			return
+		}
+	case reflect.Map:
+		if srcObject, ok := src.(map[string]interface{}); ok && dst.CanSet() {
+			dst.Set(reflect.MakeMap(ty))
+			for k, v := range srcObject {
+				path = append(path, k)
+				key := reflect.New(ty.Key())
+				keyErrs := extract(path, k, key)
+				errs = append(errs, keyErrs...)
+				if len(keyErrs) == 0 {
+					val := reflect.New(ty.Elem())
+					errs = append(errs, extract(path, v, val)...)
+					dst.SetMapIndex(key.Elem(), val.Elem())
+				}
+				path = path[:len(path)-1]
+			}
+			return
+		}
+	case reflect.Interface:
+		if dst.CanSet() {
+			dst.Set(reflect.ValueOf(src))
+			return
+		}
+	case reflect.Bool:
+		if boolean, ok := src.(bool); ok && dst.CanSet() {
+			dst.SetBool(boolean)
+			return
+		}
+	case reflect.Int:
+		if number, ok := src.(int64); ok {
+			if dst.CanSet() {
+				dst.SetInt(number)
+				return
+			}
+		} else if number, ok := src.(int); ok {
+			if dst.CanSet() {
+				dst.SetInt(int64(number))
+				return
+			}
+		} else if number, ok := src.(float64); ok {
+			if dst.CanSet() {
+				dst.SetInt(int64(number))
+				return
+			}
+		}
+	case reflect.Float64:
+		if number, ok := src.(float64); ok {
+			if dst.CanSet() {
+				dst.SetFloat(number)
+				return
+			}
+		}
+	case reflect.String:
+		if str, ok := src.(string); ok && dst.CanSet() {
+			dst.SetString(str)
+			return
+		}
+	}
+
+	return []error{newExtractError(path, src, ty)}
+}
+
+func newExtractError(path []interface{}, src interface{}, dst reflect.Type) ExtractError {
+	pcopy := make([]interface{}, len(path))
+	copy(pcopy, path)
+	return ExtractError{
+		SrcPath: pcopy,
+		SrcType: reflect.TypeOf(src),
+		DstType: dst,
+	}
+}
+
+func getJsonFieldName(field reflect.StructField) (string, bool) {
+	tag, ok := field.Tag.Lookup("json")
+	if !ok {
+		return "", false
+	}
+	pieces := strings.SplitN(tag, ",", 2)
+	if len(pieces) >= 1 {
+		return pieces[0], true
+	}
+	return "", false
+}

--- a/pkg/interfacetricks/extract_test.go
+++ b/pkg/interfacetricks/extract_test.go
@@ -1,0 +1,114 @@
+package interfacetricks
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type Primitives struct {
+	Bool    bool    `json:"bool"`
+	Int     int     `json:"int,omitempty"`
+	Float64 float64 `json:"float64"`
+	String  string  `json:"string"`
+}
+
+func TestPrimitives(t *testing.T) {
+	p1 := Primitives{}
+	p2 := Primitives{}
+	PropertyCompareToEncoding(t, Primitives{
+		Bool:    true,
+		Int:     4,
+		Float64: 3.14,
+		String:  "Hello, world!",
+	}, &p1, &p2)
+
+	p1 = Primitives{}
+	p2 = Primitives{}
+	PropertyCompareToEncoding(t, Primitives{
+		Bool:   false,
+		String: "Hello, world!",
+	}, &p1, &p2)
+}
+
+type Collections struct {
+	Slice []Primitives   `json:"slice"`
+	Map   map[string]int `json:"map"`
+}
+
+func TestCollections(t *testing.T) {
+	c1 := Collections{}
+	c2 := Collections{}
+	PropertyCompareToEncoding(t, Collections{
+		Slice: []Primitives{
+			{String: "one!"},
+			{String: "two!"},
+		},
+		Map: map[string]int{
+			"three": 3,
+			"four":  4,
+		},
+	}, &c1, &c2)
+}
+
+func TestCollectionErrors(t *testing.T) {
+	stringType := reflect.TypeOf("foo")
+	boolType := reflect.TypeOf(true)
+	intType := reflect.TypeOf(int(1))
+	dst := Collections{}
+	errs := Extract(map[string]interface{}{
+		"slice": []interface{}{
+			int(1), // Error!
+			map[string]interface{}{
+				"string": "Hello, world!",
+				"bool":   "not actually a bool",
+			},
+		},
+	}, &dst)
+	require.Equal(t, []error{
+		ExtractError{
+			SrcPath: []interface{}{"slice", 0},
+			SrcType: intType,
+			DstType: reflect.TypeOf(Primitives{}),
+		},
+		ExtractError{
+			SrcPath: []interface{}{"slice", 1, "bool"},
+			SrcType: stringType,
+			DstType: boolType,
+		},
+	}, errs)
+	require.Equal(t, Collections{
+		Slice: []Primitives{
+			{},
+			{String: "Hello, world!"},
+		},
+	}, dst)
+}
+
+// PropertyCompareToEncoding helps testing the Extract function.  We deserialize
+// a value twice --- once using a JSON round-trip, and once using our own
+// Extract.  We expect the result to be the same.
+func PropertyCompareToEncoding(
+	t *testing.T,
+	src interface{},
+	usingJson interface{},
+	usingExtract interface{},
+) {
+	// JSON round-trip
+	bytes, err := json.Marshal(src)
+	require.NoError(t, err)
+	err = json.Unmarshal(bytes, usingJson)
+	require.NoError(t, err)
+
+	// First decode to generic interface{}, then Extract.
+	var value interface{}
+	err = json.Unmarshal(bytes, &value)
+	require.NoError(t, err)
+	require.Nil(t, Extract(value, usingExtract))
+
+	// Should be the same.
+	assert.Equal(t, usingJson, usingExtract)
+}


### PR DESCRIPTION
This adds support for evaluating ARM template expressions during the resource discovery phase.  Concretely, this means that we apply the currently supported functions to `name`, `type` and `tags` (as well as the other parts where we were already doing this).  Because of the phased approach, the `resourceId` function is not available when we evaluate `name` and `type` expressions.

Reviewer notes:

 -  I did a major refactoring to `arm.go` to avoid modifying stuff in place and implement a cleaner pipeline, mostly keeping the existing naming:

        arm_Template -> arm_DiscoverResource -> arm_Resource

    We store the errors at each point during this processing / evaluation.

    The "accessor" functions (`ToState()`, `Errors()`) do read-only conversion from the internal model (`arm_Resource`) to the external resource (`models.ResourceState`).

 -  I removed the variables and discovered resources from `EvaluationContext` since they are only useful to a single builtin.  This was actually closer to how Craig originally wrote it...  Instead, these builtins take only the pieces they need and return a `Function` type.

 -  I moved the list of builtins to `builtins.go`, so it is more readable for non-programmers who follow the list in `pkg/input/arm/README.md`.

 -  The phased approach needed multiple passes of JSON serialization and deserialization.  This created two problems:

     *  We consume a huge amount of memory since we are creating copies of
        all strings in the input (not that important).
     *  It makes it very hard to recover from errors with custom unmarshallers
        (like e.g. the now-deleted `arm_Tags` code).

    To fix this, I added a new component to `interfacetricks`, `extract.go`. This is similar to the existing `./pkg/rego/bind.go` which also helped a lot.

    `extract.go` provides a pretty clean way to do flexible unmarhsalling of `interface{}`-like things to custom structures, and ignore errors.  This made writing the new `arm.go` a lot easier and I suspect it will also be hugely helpful when we improve `cfn.go` or tackle Helm.