### PR TITLE
Add capabilities subcommand and upload extra files (CLOUD-1680)

### DIFF
--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -21,5 +21,7 @@ jobs:
         run: echo "VERSION=v${GITHUB_REF#*release/}" >> $GITHUB_OUTPUT
       - name: Ensure changelog exists
         run: ls changes/${{ steps.version.outputs.VERSION }}.md
+      - name: Generate extra files
+        run: make release_extra_files
       - name: Run goreleaser
         run: goreleaser build --snapshot

--- a/.github/workflows/release_manual.yml
+++ b/.github/workflows/release_manual.yml
@@ -22,6 +22,8 @@ jobs:
       run: echo "TAG_NAME=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
     - name: Ensure changelog exists
       run: ls changes/${{ steps.tag_name.outputs.TAG_NAME }}.md
+    - name: Generate extra files
+      run: make release_extra_files
     - name: Run goreleaser
       run: |
         goreleaser release \

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -27,6 +27,8 @@ jobs:
         echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
     - name: Ensure changelog exists
       run: ls changes/${{ steps.version.outputs.VERSION }}.md
+    - name: Generate extra files
+      run: make release_extra_files
     - name: Tag version
       run: |
         VERSION=${{ steps.version.outputs.VERSION }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /dist/
 /policy-engine
+/release_extra_files/
 .scratch
 .vscode
 .idea

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,3 +9,7 @@ builds:
 
   ldflags:
   - -s -w -X github.com/snyk/policy-engine/pkg/version.Version={{.Version}}
+
+release:
+  extra_files:
+  - glob: ./release_extra_files/*

--- a/Makefile
+++ b/Makefile
@@ -132,3 +132,16 @@ vendor_terraform:
 	git apply patches/terraform.patch
 	go mod tidy
 	rm -rf terraform.zip terraform-$(TERRAFORM_VERSION)
+
+# Produce extra files that should be attached to releases:
+#
+# - capabilities.json
+# - regolib.tar.gz
+.PHONY: release_extra_files
+release_extra_files:
+	mkdir -p release_extra_files/
+	go run . capabilities >release_extra_files/capabilities.json
+	find rego/ -name '*.rego' \
+		-a -! -name '*_test.rego' \
+		-a -! -name '*_example.rego' | \
+		xargs tar -czf release_extra_files/regolib.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ vendor_terraform:
 release_extra_files:
 	mkdir -p release_extra_files/
 	go run . capabilities >release_extra_files/capabilities.json
-	find rego/ -name '*.rego' \
-		-a -! -name '*_test.rego' \
-		-a -! -name '*_example.rego' | \
+	find rego -name '*.rego' \
+		-and -not -name '*_test.rego' \
+		-and -not -name '*_example.rego' | \
 		xargs tar -czf release_extra_files/regolib.tar.gz

--- a/changes/unreleased/Added-20230814-102123.yaml
+++ b/changes/unreleased/Added-20230814-102123.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: capabilities subcommand
+time: 2023-08-14T10:21:23.969939809+02:00

--- a/changes/unreleased/Added-20230814-102137.yaml
+++ b/changes/unreleased/Added-20230814-102137.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: upload extra files to github releases
+time: 2023-08-14T10:21:37.532984971+02:00

--- a/cmd/capabilities.go
+++ b/cmd/capabilities.go
@@ -1,0 +1,39 @@
+// © 2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/snyk/policy-engine/pkg/policy"
+)
+
+var capabilitiesCmd = &cobra.Command{
+	Use:   "capabilities",
+	Short: "Output OPA-compatible capabilities document",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		caps := policy.Capabilities()
+		bytes, err := json.MarshalIndent(caps, "", "    ")
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stdout, "%s\n", string(bytes))
+		return nil
+	},
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -145,4 +145,5 @@ func init() {
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(metadataCmd)
 	rootCmd.AddCommand(evalCmd)
+	rootCmd.AddCommand(capabilitiesCmd)
 }


### PR DESCRIPTION
This tries to make it feasible to run external tooling (`opa check`, Regal) on repositories of policy-engine rules.  In order to do that, we need two things:

1.  A capabilities file that declares the custom builtins we use
2.  The rego code we use to invoke these builtins (since we don't do this directly)

There's somewhat of a choice for (2); we have "pure Rego" versions of our libraries that are used by `repl` and `test`; and we have more optimized versions used by `run`.  We choose to embed the former, since these will allow users to run code as well as statically analyze it.

This PR consists of two parts:

- Exposing the `capabilities.json` through a subcommand
- Attaching the capabilities & rego files to the releases