### PR TITLE
fix: ensure snyk.resources() are returned in a deterministic order

### DIFF
--- a/changes/unreleased/Fixed-20230816-122009.yaml
+++ b/changes/unreleased/Fixed-20230816-122009.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: ensure `snyk.resources()` are returned in a deterministic order
+time: 2023-08-16T12:20:09.431557362+02:00

--- a/pkg/policy/input_resolver.go
+++ b/pkg/policy/input_resolver.go
@@ -41,11 +41,11 @@ func (r *inputResolver) resolve(ctx context.Context, query ResourcesQuery) (Reso
 	if resources, ok := r.input.Resources[query.ResourceType]; ok {
 		ret.ScopeFound = true
 		keys := make([]string, 0, len(resources))
-		ret.Resources = make([]models.ResourceState, 0, len(resources))
 		for k := range resources {
 			keys = append(keys, k)
 		}
 		sort.Strings(keys) // Make sure to return in deterministic order
+		ret.Resources = make([]models.ResourceState, 0, len(resources))
 		for _, k := range keys {
 			ret.Resources = append(ret.Resources, resources[k])
 		}

--- a/pkg/policy/input_resolver.go
+++ b/pkg/policy/input_resolver.go
@@ -41,6 +41,7 @@ func (r *inputResolver) resolve(ctx context.Context, query ResourcesQuery) (Reso
 	if resources, ok := r.input.Resources[query.ResourceType]; ok {
 		ret.ScopeFound = true
 		keys := make([]string, 0, len(resources))
+		ret.Resources = make([]models.ResourceState, 0, len(resources))
 		for k := range resources {
 			keys = append(keys, k)
 		}

--- a/pkg/policy/input_resolver.go
+++ b/pkg/policy/input_resolver.go
@@ -40,7 +40,7 @@ func (r *inputResolver) resolve(ctx context.Context, query ResourcesQuery) (Reso
 	ret := ResourcesResult{ScopeFound: true}
 	if resources, ok := r.input.Resources[query.ResourceType]; ok {
 		ret.ScopeFound = true
-		keys := make([]string{}, 0, len(resources))
+		keys := make([]string, 0, len(resources))
 		for k := range resources {
 			keys = append(keys, k)
 		}

--- a/pkg/policy/input_resolver.go
+++ b/pkg/policy/input_resolver.go
@@ -16,6 +16,7 @@ package policy
 
 import (
 	"context"
+	"sort"
 
 	"github.com/snyk/policy-engine/pkg/models"
 )
@@ -39,8 +40,13 @@ func (r *inputResolver) resolve(ctx context.Context, query ResourcesQuery) (Reso
 	ret := ResourcesResult{ScopeFound: true}
 	if resources, ok := r.input.Resources[query.ResourceType]; ok {
 		ret.ScopeFound = true
-		for _, resource := range resources {
-			ret.Resources = append(ret.Resources, resource)
+		keys := []string{}
+		for k := range resources {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys) // Make sure to return in deterministic order
+		for _, k := range keys {
+			ret.Resources = append(ret.Resources, resources[k])
 		}
 	}
 	r.calledWith[query.ResourceType] = true

--- a/pkg/policy/input_resolver.go
+++ b/pkg/policy/input_resolver.go
@@ -40,7 +40,7 @@ func (r *inputResolver) resolve(ctx context.Context, query ResourcesQuery) (Reso
 	ret := ResourcesResult{ScopeFound: true}
 	if resources, ok := r.input.Resources[query.ResourceType]; ok {
 		ret.ScopeFound = true
-		keys := []string{}
+		keys := make([]string{}, 0, len(resources))
 		for k := range resources {
 			keys = append(keys, k)
 		}

--- a/pkg/policy/input_resolver_test.go
+++ b/pkg/policy/input_resolver_test.go
@@ -1,0 +1,35 @@
+package policy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/snyk/policy-engine/pkg/models"
+)
+
+func TestInputResolverDeterministic(t *testing.T) {
+	resource1 := models.ResourceState{
+		Id:           "bucket_1",
+		ResourceType: "aws_s3_bucket",
+	}
+	resource2 := models.ResourceState{
+		Id:           "bucket_2",
+		ResourceType: "aws_s3_bucket",
+	}
+	input := models.State{
+		Resources: map[string]map[string]models.ResourceState{
+			"aws_s3_bucket": map[string]models.ResourceState{
+				resource1.Id: resource1,
+				resource2.Id: resource2,
+			},
+		},
+	}
+	resolver := newInputResolver(&input)
+	result, err := resolver.resolve(context.Background(), ResourcesQuery{
+		ResourceType: "aws_s3_bucket",
+	})
+	require.NoError(t, err)
+	require.Equal(t, []models.ResourceState{resource1, resource2}, result.Resources)
+}


### PR DESCRIPTION
I want to `diff` rule results in another repo and see if any changes are made.  Go's random map iteration is causing spurious differences there.