### PR TITLE
chore: remove __resources_by_type

### DIFF
--- a/changes/unreleased/Updated-20230816-132757.yaml
+++ b/changes/unreleased/Updated-20230816-132757.yaml
@@ -1,0 +1,3 @@
+kind: Updated
+body: remove __resources_by_type builtin
+time: 2023-08-16T13:27:57.541046212+02:00

--- a/pkg/policy/regoapi/fugue.rego
+++ b/pkg/policy/regoapi/fugue.rego
@@ -25,7 +25,9 @@ resource_types_v0 := input_resource_types
 resource_types := input_resource_types
 
 resources(resource_type) = ret {
-  ret := __resources_by_type(resource_type)
+  ret := {r.id: r |
+     r := __query({"resource_type": resource_type, "scope": {}})[_]
+   }
 }
 
 allow_resource(resource) = ret {


### PR DESCRIPTION
Quite a while ago we added `__query` as an enhanced version of `__resources_by_type` that can take "scope" into account.  This would allow us to retrieve runtime resources using cloud context.

`__resources_by_type` can be written in terms of `__query`, so we can get rid of a builtin by doing this.