### PR TITLE
chore: use rego.Bind to parse resources query

### DIFF
--- a/changes/unreleased/Updated-20230816-141748.yaml
+++ b/changes/unreleased/Updated-20230816-141748.yaml
@@ -1,0 +1,3 @@
+kind: Updated
+body: refactor unmarshalling of resources query
+time: 2023-08-16T14:17:48.58234+02:00

--- a/pkg/policy/api.go
+++ b/pkg/policy/api.go
@@ -39,8 +39,8 @@ var RegoAPIProvider = data.FSProvider(regoApi, "regoapi")
 // ResourcesQuery describes a request for a specific resource type from the given scope.
 // An empty scope is interpreted as the scope of the current input.
 type ResourcesQuery struct {
-	ResourceType string            `json:"resource_type"`
-	Scope        map[string]string `json:"scope"`
+	ResourceType string            `json:"resource_type" rego:"resource_type"`
+	Scope        map[string]string `json:"scope" rego:"scope"`
 }
 
 // ResourcesResult contains an indication of whether the Scope specified in the


### PR DESCRIPTION
This package is preferred over manually extracting objects, and it deals with errors more gracefully (e.g. the string casts).