### PR TITLE
chore: refactor resources query

### DIFF
--- a/changes/unreleased/Changed-20230816-142851.yaml
+++ b/changes/unreleased/Changed-20230816-142851.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'BREAKING: EvalOptions now takes a ResourcesQueryCache instead of a ResourcesResolver'
+time: 2023-08-16T14:28:51.505446+02:00

--- a/pkg/engine/policyset.go
+++ b/pkg/engine/policyset.go
@@ -435,7 +435,7 @@ type QueryOptions struct {
 	Query string
 	// Input is an optional state to query against
 	Input *models.State
-	// ResourceResolver determines how your query will resolve resource queries.
+	// ResourcesQuery determines how your query will resolve resource queries.
 	// This is required if the query will end up requesting resource information.
 	ResourcesQuery *policy.ResourcesQueryCache
 	// ResultProcessor is a function that is run on every result returned by the

--- a/pkg/engine/policyset.go
+++ b/pkg/engine/policyset.go
@@ -172,10 +172,10 @@ func (s *policySet) compile(ctx context.Context) error {
 }
 
 type evalPolicyOptions struct {
-	resourcesResolver policy.ResourcesResolver
-	policy            policy.Policy
-	input             *models.State
-	relationsCache    *policy.RelationsCache
+	policy              policy.Policy
+	input               *models.State
+	resourcesQueryCache *policy.ResourcesQueryCache
+	relationsCache      *policy.RelationsCache
 }
 
 func (s *policySet) evalPolicy(ctx context.Context, options *evalPolicyOptions) policyResults {
@@ -184,12 +184,12 @@ func (s *policySet) evalPolicy(ctx context.Context, options *evalPolicyOptions) 
 	instrumentation.startEval(ctx)
 
 	ruleResults, err := pol.Eval(ctx, policy.EvalOptions{
-		RegoState:         s.rego,
-		Logger:            instrumentation.logger,
-		ResourcesResolver: options.resourcesResolver,
-		Input:             options.input,
-		RelationsCache:    options.relationsCache,
-		Timeout:           s.timeouts.Query,
+		RegoState:           s.rego,
+		Logger:              instrumentation.logger,
+		ResourcesQueryCache: options.resourcesQueryCache,
+		Input:               options.input,
+		RelationsCache:      options.relationsCache,
+		Timeout:             s.timeouts.Query,
 	})
 	totalResults := 0
 	for idx, r := range ruleResults {
@@ -254,11 +254,11 @@ func (s *policySet) ruleIDFilter(ruleIDs []string) policyFilter {
 }
 
 type parallelEvalOptions struct {
-	resourcesResolver policy.ResourcesResolver
-	workers           int
-	input             *models.State
-	ruleIDs           []string
-	loggerFields      []loggerOption
+	workers        int
+	input          *models.State
+	resourcesQuery *policy.ResourcesQueryCache
+	ruleIDs        []string
+	loggerFields   []loggerOption
 }
 
 func (s *policySet) eval(ctx context.Context, options *parallelEvalOptions) ([]models.RuleResults, error) {
@@ -281,7 +281,7 @@ func (s *policySet) eval(ctx context.Context, options *parallelEvalOptions) ([]m
 	}
 
 	// Precompute relations
-	relationsCache, err := s.precomputeRelationsCache(ctx, options.input, options.resourcesResolver)
+	relationsCache, err := s.precomputeRelationsCache(ctx, options.input, options.resourcesQuery)
 	if err != nil {
 		return nil, newRuleBundleError(
 			s.ruleBundle(),
@@ -314,10 +314,10 @@ func (s *policySet) eval(ctx context.Context, options *parallelEvalOptions) ([]m
 						return
 					}
 					resultsChan <- s.evalPolicy(ctx, &evalPolicyOptions{
-						resourcesResolver: options.resourcesResolver,
-						policy:            p,
-						input:             options.input,
-						relationsCache:    relationsCache,
+						policy:              p,
+						input:               options.input,
+						resourcesQueryCache: options.resourcesQuery,
+						relationsCache:      relationsCache,
 					})
 				}
 			}()
@@ -348,7 +348,7 @@ func (s *policySet) eval(ctx context.Context, options *parallelEvalOptions) ([]m
 func (s *policySet) precomputeRelationsCache(
 	ctx context.Context,
 	input *models.State,
-	resourcesResolver policy.ResourcesResolver,
+	resourcesQuery *policy.ResourcesQueryCache,
 ) (*policy.RelationsCache, error) {
 	s.instrumentation.startPrecomputeRelations(ctx)
 	defer s.instrumentation.finishPrecomputeRelations(ctx)
@@ -358,9 +358,9 @@ func (s *policySet) precomputeRelationsCache(
 	err := s.query(
 		ctx,
 		&QueryOptions{
-			Query:             "data.snyk.internal.relations.forward",
-			Input:             input,
-			ResourcesResolver: resourcesResolver,
+			Query:          "data.snyk.internal.relations.forward",
+			Input:          input,
+			ResourcesQuery: resourcesQuery,
 			ResultProcessor: func(val ast.Value) error {
 				relationsCache.Forward = val
 				found = true
@@ -379,9 +379,9 @@ func (s *policySet) precomputeRelationsCache(
 	err = s.query(
 		ctx,
 		&QueryOptions{
-			Query:             "data.snyk.internal.relations.backward",
-			Input:             input,
-			ResourcesResolver: resourcesResolver,
+			Query:          "data.snyk.internal.relations.backward",
+			Input:          input,
+			ResourcesQuery: resourcesQuery,
 			ResultProcessor: func(val ast.Value) error {
 				relationsCache.Backward = val
 				found = true
@@ -435,10 +435,9 @@ type QueryOptions struct {
 	Query string
 	// Input is an optional state to query against
 	Input *models.State
-	// ResourceResolver is an optional function that returns a resource state
-	// for the given ResourceRequest. Multiple ResourcesResolvers can be
-	// composed with And() and Or().
-	ResourcesResolver policy.ResourcesResolver
+	// ResourceResolver determines how your query will resolve resource queries.
+	// This is required if the query will end up requesting resource information.
+	ResourcesQuery *policy.ResourcesQueryCache
 	// ResultProcessor is a function that is run on every result returned by the
 	// query.
 	ResultProcessor func(ast.Value) error
@@ -449,7 +448,7 @@ func (s *policySet) query(ctx context.Context, options *QueryOptions) error {
 	if input == nil {
 		input = &models.State{}
 	}
-	builtins := policy.NewBuiltins(input, options.ResourcesResolver, nil)
+	builtins := policy.NewBuiltins(input, options.ResourcesQuery, nil)
 	return s.rego.Query(ctx, rego.Query{
 		Query:    options.Query,
 		Builtins: builtins.Implementations(),

--- a/pkg/policy/base.go
+++ b/pkg/policy/base.go
@@ -59,12 +59,12 @@ var SupportedInputTypes = input.Types{
 }
 
 type EvalOptions struct {
-	RegoState         *rego.State
-	Input             *models.State
-	RelationsCache    *RelationsCache
-	Logger            logging.Logger
-	ResourcesResolver ResourcesResolver
-	Timeout           time.Duration
+	RegoState           *rego.State
+	Input               *models.State
+	RelationsCache      *RelationsCache
+	ResourcesQueryCache *ResourcesQueryCache
+	Logger              logging.Logger
+	Timeout             time.Duration
 }
 
 // Policy is an interface that supports all of the ways we want to interact

--- a/pkg/policy/input_resolver_test.go
+++ b/pkg/policy/input_resolver_test.go
@@ -26,8 +26,8 @@ func TestInputResolverDeterministic(t *testing.T) {
 			},
 		},
 	}
-	resolver := newInputResolver(&input)
-	result, err := resolver.resolve(context.Background(), ResourcesQuery{
+	resolver := NewInputResolver(&input)
+	result, err := resolver(context.Background(), ResourcesQuery{
 		ResourceType: "aws_s3_bucket",
 	})
 	require.NoError(t, err)

--- a/pkg/policy/legacyiac.go
+++ b/pkg/policy/legacyiac.go
@@ -85,7 +85,7 @@ func (p *LegacyIaCPolicy) Eval(
 			logger.Error(ctx, "Failed to prepare input")
 			return p.errorOutput(err)
 		}
-		builtins := NewBuiltins(options.Input, options.ResourcesResolver, nil)
+		builtins := NewBuiltins(options.Input, options.ResourcesQueryCache, nil)
 		strictBuiltinErrors := false
 		query := rego.Query{
 			Builtins:            builtins.Implementations(),

--- a/pkg/policy/multi.go
+++ b/pkg/policy/multi.go
@@ -73,7 +73,7 @@ func (p *MultiResourcePolicy) Eval(
 	}
 	defaultRemediation := metadata.RemediationFor(options.Input.InputType)
 	metadata.copyToRuleResults(options.Input.InputType, &output)
-	builtins := NewBuiltins(options.Input, options.ResourcesResolver, options.RelationsCache)
+	builtins := NewBuiltins(options.Input, options.ResourcesQueryCache, options.RelationsCache)
 	tracer := inferattributes.NewTracer()
 
 	query := rego.Query{

--- a/pkg/policy/query_test.go
+++ b/pkg/policy/query_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestResolveResources_SingleResolver_ReturnsZeroResourcesWhenNoResolversMatch(t *testing.T) {
-	q := &policy.Query{ResourcesResolver: policy.ResourcesResolver(nonMatchingResolver)}
+	q := &policy.ResourcesQueryCache{ResourcesResolver: policy.ResourcesResolver(nonMatchingResolver)}
 	res, err := q.ResolveResources(context.Background(), policy.ResourcesQuery{})
 	require.NoError(t, err)
 	assert.Empty(t, res)
@@ -46,7 +46,7 @@ func TestResolveResources_ComposedWithOr_ReturnsResourcesFromFirstMatchingResolv
 			Resources:  expectedResources,
 		}, nil
 	}
-	q := &policy.Query{
+	q := &policy.ResourcesQueryCache{
 		ResourcesResolver: policy.ResourcesResolver(nonMatchingResolver).
 			Or(spyResolver).
 			Or(panickyResolver),
@@ -62,7 +62,7 @@ func TestResolveResources_ComposedWithOr_ReturnsErrorFromFirstResolverThatErrors
 		assert.Equal(t, req, query)
 		return policy.ResourcesResult{}, errors.New("oops")
 	}
-	q := &policy.Query{
+	q := &policy.ResourcesQueryCache{
 		ResourcesResolver: policy.ResourcesResolver(nonMatchingResolver).
 			Or(spyResolver).
 			Or(panickyResolver),
@@ -99,7 +99,7 @@ func TestResolveResources_ComposedWithAnd_ReturnsResourcesFromBothMatchingResolv
 		}, nil
 	}
 
-	q := &policy.Query{
+	q := &policy.ResourcesQueryCache{
 		ResourcesResolver: policy.ResourcesResolver(spyResolver1).
 			And(spyResolver2),
 	}
@@ -114,7 +114,7 @@ func TestResolveResources_ComposedWithAnd_ReturnsErrorFromFirstResolverThatError
 		assert.Equal(t, req, query)
 		return policy.ResourcesResult{}, errors.New("oops")
 	}
-	q := &policy.Query{
+	q := &policy.ResourcesQueryCache{
 		ResourcesResolver: policy.ResourcesResolver(nonMatchingResolver).
 			And(spyResolver).
 			And(panickyResolver),
@@ -143,7 +143,7 @@ func TestResolveResources_ComplexChainOfAndsAndOrs(t *testing.T) {
 		}
 	}
 
-	q := &policy.Query{
+	q := &policy.ResourcesQueryCache{
 		ResourcesResolver: policy.ResourcesResolver(nonMatchingResolver).
 			Or(
 				mkstub("some-resource-1").And(


### PR DESCRIPTION
The `inputResolver` was responsible for two things:

- Returning resources from the input
- Tracking which resource types were used by policy

This change splits that apart, adding a new `trackResourceTypes` to `Query` takes care of the latter.

Aside from making input resolver code a bit simpler, this has the advantage that we can now create the `Query` once (per input) and still set the tracked resource types map per policy.  This will allow good caching in `Query`.

This caching itself will be included in a follow-up PR.

It would be better to make a caching `ResourcesResolver`, but unfortunately it doesn't have the right return type (and asking users of the library to produce a Rego `ast.Term` is weird...).  This results in the unfortunate fact that we need to change the thing we pass around from a `ResourcesResolver` to a `Query` everywhere.

Since we are changing the types around this a bit; I also renamed `policy.Query` to `policy.ResourcesQueryCache`, since query is very much an overloaded word.