### PR TITLE
chore: clarify extra fields in metadata

### DIFF
--- a/changes/unreleased/Updated-20230822-115049.yaml
+++ b/changes/unreleased/Updated-20230822-115049.yaml
@@ -1,0 +1,3 @@
+kind: Updated
+body: clarify that custom metadata fields are ignored
+time: 2023-08-22T11:50:49.687803+02:00

--- a/docs/policy_spec.md
+++ b/docs/policy_spec.md
@@ -185,8 +185,9 @@ The `metadata` rule defines static metadata associated with the policy. See the
 #### Supported fields
 
 **NOTE** that `policy-engine` by itself does not enforce any restrictions on
-metadata fields apart from their data type. The descriptions below are mostly intended
-to clarify the intent of each field.
+metadata fields apart from their data type.  Custom, extra fields can be added
+but these will not be present in the `policy-engine` output.  The descriptions
+below are mostly intended to clarify the intent of each field.
 
 | Field           |  Type  | Description                                                                                                      |
 | :-------------- | :----: | :--------------------------------------------------------------------------------------------------------------- |

--- a/examples/metadata/rules/snyk_001/metadata.json
+++ b/examples/metadata/rules/snyk_001/metadata.json
@@ -36,6 +36,7 @@
       "CIS-AWS_v1.3.0_5.2",
       "CIS-AWS_v1.4.0_6.7"
     ],
-    "severity": "Critical"
+    "severity": "Critical",
+    "custom_field": "Hello! I am a custom field. I should not end up in the output for now"
   }
 }

--- a/pkg/policy/base.go
+++ b/pkg/policy/base.go
@@ -398,7 +398,7 @@ func (p *BasePolicy) Metadata(
 		return m, fmt.Errorf("Unrecognized metadata rule: %s", p.metadataRule.name)
 	}
 	if m.Kind == "" {
-		m.Kind = "vulnerability"
+		m.Kind = defaultKind
 	}
 	p.cachedMetadata = &m
 	return m, nil


### PR DESCRIPTION
- Clarify that extra fields can be present in metadata
- Add a test for this
- Change hardcoded `vulnerability` string to the `const` we already have