### PR TITLE
Fix non-string variables defaulting to strings (CLOUD-1717)

### DIFF
--- a/changes/unreleased/Fixed-20230901-173949.yaml
+++ b/changes/unreleased/Fixed-20230901-173949.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: non-string variables defaulting to string instead of null
+time: 2023-09-01T17:39:49.890115566+02:00

--- a/pkg/hcl_interpreter/moduletree.go
+++ b/pkg/hcl_interpreter/moduletree.go
@@ -267,16 +267,18 @@ func walkModule(v Visitor, moduleName ModuleName, module *configs.Module, variab
 			}
 			v.VisitTerm(name.Add("variable").Add(variable.Name), TermFromExpr(&expr))
 		} else {
-			// If no default is provided, we can add our own default depending
-			// on the type.  We currently only do this for strings.
+			val := cty.NullVal(variable.Type)
 			if variable.Type == cty.String {
+				// If no default is provided, we can add our own default depending
+				// on the type.  We currently only do this for strings.
 				selfRef := name.Add("var").Add(variable.Name).ToString()
-				expr := hclsyntax.LiteralValueExpr{
-					Val:      cty.StringVal(selfRef),
-					SrcRange: variable.DeclRange,
-				}
-				v.VisitTerm(name.Add("variable").Add(variable.Name), TermFromExpr(&expr))
+				val = cty.StringVal(selfRef)
 			}
+			expr := hclsyntax.LiteralValueExpr{
+				Val:      val,
+				SrcRange: variable.DeclRange,
+			}
+			v.VisitTerm(name.Add("variable").Add(variable.Name), TermFromExpr(&expr))
 		}
 	}
 

--- a/pkg/input/golden_test/tf/null-vars.json
+++ b/pkg/input/golden_test/tf/null-vars.json
@@ -1,0 +1,31 @@
+{
+  "format": "",
+  "format_version": "",
+  "input_type": "tf_hcl",
+  "environment_provider": "iac",
+  "meta": {
+    "filepath": "golden_test/tf/null-vars/main.tf"
+  },
+  "resources": {
+    "aws_s3_bucket": {
+      "aws_s3_bucket.main": {
+        "id": "aws_s3_bucket.main",
+        "resource_type": "aws_s3_bucket",
+        "namespace": "golden_test/tf/null-vars/main.tf",
+        "tags": {
+          "foo": "bar"
+        },
+        "meta": {},
+        "attributes": {
+          "bucket_prefix": "store-var.app",
+          "tags": {
+            "foo": "bar"
+          }
+        }
+      }
+    }
+  },
+  "scope": {
+    "filepath": "golden_test/tf/null-vars/main.tf"
+  }
+}

--- a/pkg/input/golden_test/tf/null-vars/main.tf
+++ b/pkg/input/golden_test/tf/null-vars/main.tf
@@ -1,0 +1,17 @@
+variable "app" {
+	type = string
+}
+
+variable "tags_1" {
+	type = map
+}
+
+variable "tags_2" {
+	type = map
+	default = {"foo": "bar"}
+}
+
+resource "aws_s3_bucket" "main" {
+	bucket_prefix = "store-${var.app}"
+	tags          = merge(var.tags_1, var.tags_2)
+}


### PR DESCRIPTION
Currently, unset variables default to their variable name.  This is a somewhat unfortunate artefact inherited from Regula, and may be worth fixing at a different point.  But it is somewhat useful if variable names are used as resource IDs; e.g.:

    variable "app" {
    	type = string
    }

    resource "aws_s3_bucket" "main" {
    	bucket_prefix = "store-${var.app}"
    }

And then you'd see `"store-var.app"` in the output which makes some rules easier to write (which is debatable).

This changes that behavior for **non-string** variables.  Since we know these aren't strings, setting them to the variable name breaks evaluation by throwing type errors in many cases, for example:

    variable "tags_1" {
    	type = map
    }

    variable "tags_2" {
    	type = map
    	default = {"foo": "bar"}
    }

    resource "aws_s3_bucket" "main" {
    	tags = merge(var.tags_1, var.tags_2)
    }

...where we try to merge an object with the string `"var.tags_1"`.

Terraform sets unset default variables to `null`, so we should follow that: https://developer.hashicorp.com/terraform/language/values/variables#disallowing-null-input-values

A follow-up change to this could include setting zero values (e.g. an empty list for lists) when `nullable = false`.