### PR TITLE
fix: remote submodule register bug

### DIFF
--- a/changes/unreleased/Fixed-20230904-132306.yaml
+++ b/changes/unreleased/Fixed-20230904-132306.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: issue parsing remote terraform module register
+time: 2023-09-04T13:23:06.274955918+02:00

--- a/pkg/hcl_interpreter/hcl_interpreter.go
+++ b/pkg/hcl_interpreter/hcl_interpreter.go
@@ -64,8 +64,8 @@ func AnalyzeModuleTree(mtree *ModuleTree) *Analysis {
 	return analysis
 }
 
-func (v *Analysis) VisitModule(name ModuleName, meta *ModuleMeta) {
-	v.Modules[ModuleNameToString(name)] = meta
+func (v *Analysis) VisitModule(meta *ModuleMeta) {
+	v.Modules[ModuleNameToString(meta.Name)] = meta
 }
 
 func (v *Analysis) VisitResource(name FullName, resource *ResourceMeta) {

--- a/pkg/hcl_interpreter/names.go
+++ b/pkg/hcl_interpreter/names.go
@@ -55,6 +55,26 @@ func ModuleNameToString(moduleName ModuleName) string {
 	return str
 }
 
+// ModuleNameToKey produces the internal key used in some parts of terraform
+// for modules.  While the user-exposed name (as returned by ModuleNameToString)
+// would be something like:
+//
+//	module.foo.module.lambda
+//
+// The internal key will be:
+//
+//	foo.lambda
+func ModuleNameToKey(moduleName ModuleName) string {
+	return strings.Join(moduleName, ".")
+}
+
+func ChildModuleName(moduleName ModuleName, childName string) ModuleName {
+	out := make(ModuleName, len(moduleName)+1)
+	copy(out, moduleName)
+	out[len(moduleName)] = childName
+	return out
+}
+
 type LocalName = []string
 
 func LocalNameToString(name LocalName) string {

--- a/pkg/input/golden_test/tf/module-register.json
+++ b/pkg/input/golden_test/tf/module-register.json
@@ -1,0 +1,25 @@
+{
+  "format": "",
+  "format_version": "",
+  "input_type": "tf_hcl",
+  "environment_provider": "iac",
+  "meta": {
+    "filepath": "golden_test/tf/module-register"
+  },
+  "resources": {
+    "aws_s3_bucket": {
+      "module.localmodule.module.remotemodule.aws_s3_bucket.mybucket": {
+        "id": "module.localmodule.module.remotemodule.aws_s3_bucket.mybucket",
+        "resource_type": "aws_s3_bucket",
+        "namespace": "golden_test/tf/module-register",
+        "meta": {},
+        "attributes": {
+          "bucket_prefix": "stuff"
+        }
+      }
+    }
+  },
+  "scope": {
+    "filepath": "golden_test/tf/module-register"
+  }
+}

--- a/pkg/input/golden_test/tf/module-register/.terraform/modules/localmodule.remotemodule/main.tf
+++ b/pkg/input/golden_test/tf/module-register/.terraform/modules/localmodule.remotemodule/main.tf
@@ -1,0 +1,3 @@
+resource "aws_s3_bucket" "mybucket" {
+  bucket_prefix = "stuff"
+}

--- a/pkg/input/golden_test/tf/module-register/.terraform/modules/modules.json
+++ b/pkg/input/golden_test/tf/module-register/.terraform/modules/modules.json
@@ -1,0 +1,20 @@
+{
+  "Modules": [
+    {
+      "Key": "",
+      "Source": "",
+      "Dir": "."
+    },
+    {
+      "Key": "localmodule",
+      "Source": "./localmodule",
+      "Dir": "localmodule"
+    },
+    {
+      "Key": "localmodule.remotemodule",
+      "Source": "registry.terraform.io/terraform-aws-modules/lambda/aws",
+      "Version": "4.18.0",
+      "Dir": ".terraform/modules/localmodule.remotemodule"
+    }
+  ]
+}

--- a/pkg/input/golden_test/tf/module-register/README.md
+++ b/pkg/input/golden_test/tf/module-register/README.md
@@ -1,0 +1,8 @@
+# module-register
+
+This contains an artificial setup using remote modules.
+
+ -  `./localmodule/` requires a remote module
+ -  this remote module is already downloaded, in the same way that
+    `terraform init` would do so, with its location marked in
+    `.terraform/modules/modules.json`

--- a/pkg/input/golden_test/tf/module-register/localmodule/main.tf
+++ b/pkg/input/golden_test/tf/module-register/localmodule/main.tf
@@ -1,0 +1,3 @@
+module "remotemodule" {
+  source = "terraform-aws-modules/aws/lambda"
+}

--- a/pkg/input/golden_test/tf/module-register/main.tf
+++ b/pkg/input/golden_test/tf/module-register/main.tf
@@ -1,0 +1,3 @@
+module "localmodule" {
+  source = "./localmodule"
+}

--- a/pkg/input/tf.go
+++ b/pkg/input/tf.go
@@ -35,7 +35,16 @@ func (t *TfDetector) DetectFile(i *File, opts DetectOptions) (IACConfiguration, 
 		return nil, fmt.Errorf("%w: %v", UnrecognizedFileExtension, i.Ext())
 	}
 	dir := filepath.Dir(i.Path)
-	moduleTree, err := hcl_interpreter.ParseFiles(nil, i.Fs, false, dir, []string{i.Path}, opts.VarFiles)
+	moduleTree,
+		err := hcl_interpreter.ParseFiles(
+		nil,
+		i.Fs,
+		false,
+		dir,
+		hcl_interpreter.EmptyModuleName,
+		[]string{i.Path},
+		opts.VarFiles,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", FailedToParseInput, err)
 	}
@@ -60,7 +69,13 @@ func (t *TfDetector) DetectDirectory(i *Directory, opts DetectOptions) (IACConfi
 	}
 
 	moduleRegister := hcl_interpreter.NewTerraformRegister(i.Fs, i.Path)
-	moduleTree, err := hcl_interpreter.ParseDirectory(moduleRegister, i.Fs, i.Path, opts.VarFiles)
+	moduleTree, err := hcl_interpreter.ParseDirectory(
+		moduleRegister,
+		i.Fs,
+		i.Path,
+		hcl_interpreter.EmptyModuleName,
+		opts.VarFiles,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", FailedToParseInput, err)
 	}


### PR DESCRIPTION
policy-engine does not download remote submodules by itself.  If one is used, e.g.:

    module "remotemodule" {
      source = "terraform-aws-modules/aws/lambda"
    }

We expect the user to run `terraform init` to download these modules (as some of them may be private and require creds).

`terraform init` will download these modules to somewhere in `.terraform` and update the file `.terraform/modules/modules.json`.  This second file is referred to as the "module register" in policy-engine code.

An example of this file would be:

    {
      "Modules": [
        ...
        {
          "Key": "localmodule.remotemodule",
          "Source": "registry.terraform.io/terraform-aws-modules/lambda/aws",
          "Version": "4.18.0",
          "Dir": ".terraform/modules/localmodule.remotemodule"
        }
        ...
      ]
    }

The policy-engine will read this file that `terraform init` produces, and through that we can infer that the sources for this remote module can be found in `.terraform/modules/localmodule.remotemodule`.

Terraform behaviour slightly changed during the time we introduced this -- you can see that it prepended a domain name (`registry.terraform.io`) to the module `source`.  This is problematic because we used to use `source` as a key to find the right module in the register.

---

This PR changes that to use the `Key` instead, which is expected to be more stable.

The key is the same as the module name, which we already computed in other places.  However, in order to do that, we need to compute this module name **earlier** so we have it available when we read the module register.

This is why add an extra parameter to `ParseFiles` so it can be constructed right at the start, rather than doing it later during the `VisitModule` pass. Since we compute it earlier, I also stored it in the `ModuleMeta` so we can remove it as an extra parameter to `VisitModule`.

We also add a test which reproduces all of this.