### PR TITLE
fix: add source code locations to missing term errors

### DIFF
--- a/changes/unreleased/Fixed-20230904-141653.yaml
+++ b/changes/unreleased/Fixed-20230904-141653.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: add source code location to missing term errors
+time: 2023-09-04T14:16:53.074091429+02:00

--- a/pkg/hcl_interpreter/errors.go
+++ b/pkg/hcl_interpreter/errors.go
@@ -16,6 +16,7 @@ package hcl_interpreter
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -48,11 +49,16 @@ func (err EvaluationError) Error() string {
 }
 
 type MissingTermError struct {
-	Term string
+	Range *hcl.Range
+	Term  string
 }
 
 func (err MissingTermError) Error() string {
-	return "Missing term " + err.Term
+	msg := "Missing term " + err.Term
+	if l := err.Range; l != nil {
+		msg = fmt.Sprintf("%s:%d:%d: %s", l.Filename, l.Start.Line, l.Start.Column, msg)
+	}
+	return msg
 }
 
 var errUnhandledValueType = errors.New("Unhandled value type")

--- a/pkg/hcl_interpreter/term.go
+++ b/pkg/hcl_interpreter/term.go
@@ -155,7 +155,12 @@ func (t Term) VisitExpressions(f func(hcl.Expression)) {
 	}
 }
 
-func (t Term) Dependencies() []hcl.Traversal {
+type TermDependency struct {
+	Range     *hcl.Range // Optional range
+	Traversal hcl.Traversal
+}
+
+func (t Term) Dependencies() []TermDependency {
 	// If the variable matches the iterator, it is not a real dependency
 	// and we can filter it out.
 	filter := func(v hcl.Traversal) bool { return false }
@@ -165,11 +170,15 @@ func (t Term) Dependencies() []hcl.Traversal {
 		}
 	}
 
-	dependencies := []hcl.Traversal{}
+	dependencies := []TermDependency{}
 	t.shallowVisitExpressions(func(e hcl.Expression) {
 		for _, variable := range e.Variables() {
 			if !filter(variable) {
-				dependencies = append(dependencies, variable)
+				loc := e.Range()
+				dependencies = append(dependencies, TermDependency{
+					Range:     &loc,
+					Traversal: variable,
+				})
 			}
 		}
 	})
@@ -177,7 +186,7 @@ func (t Term) Dependencies() []hcl.Traversal {
 	for _, blocks := range t.blocks {
 		for _, block := range blocks {
 			for _, variable := range block.Dependencies() {
-				if !filter(variable) {
+				if !filter(variable.Traversal) {
 					dependencies = append(dependencies, variable)
 				}
 			}


### PR DESCRIPTION
This adds an optional `hcl.Range` to missing term errors that we can propagate to the user.