### PR TITLE
fix: spurious warnings for default for_each iterator

### DIFF
--- a/changes/unreleased/Fixed-20230904-161021.yaml
+++ b/changes/unreleased/Fixed-20230904-161021.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: remove spurious warnings for default iterator
+time: 2023-09-04T16:10:21.128028096+02:00

--- a/pkg/hcl_interpreter/moduletree.go
+++ b/pkg/hcl_interpreter/moduletree.go
@@ -341,7 +341,7 @@ func walkResource(
 	if haveCount {
 		term = term.WithCount(resource.Count)
 	} else if haveForEach {
-		term = term.WithForEach(resource.ForEach)
+		term = term.WithForEach("each", resource.ForEach)
 	}
 
 	v.VisitTerm(name, term)

--- a/pkg/hcl_interpreter/term.go
+++ b/pkg/hcl_interpreter/term.go
@@ -122,8 +122,9 @@ func (t Term) WithCount(expr hcl.Expression) Term {
 	return t
 }
 
-func (t Term) WithForEach(expr hcl.Expression) Term {
+func (t Term) WithForEach(iterator string, expr hcl.Expression) Term {
 	t.forEach = &expr
+	t.iterator = iterator
 	return t
 }
 
@@ -304,12 +305,8 @@ func (t Term) Evaluate(
 
 			arr := []cty.Value{}
 			for _, each := range eaches {
-				iterator := "each"
-				if t.iterator != "" {
-					iterator = t.iterator
-				}
 				val, diags := t.evaluateExpr(func(e hcl.Expression, v cty.Value) (cty.Value, hcl.Diagnostics) {
-					v = MergeVal(v, NestVal(LocalName{iterator}, each))
+					v = MergeVal(v, NestVal(LocalName{t.iterator}, each))
 					return evalExpr(e, v)
 				})
 				diagnostics = append(diagnostics, diags...)

--- a/pkg/input/golden_test/tf/regula-issue-397.json
+++ b/pkg/input/golden_test/tf/regula-issue-397.json
@@ -77,8 +77,8 @@
         "meta": {},
         "attributes": {
           "for_each": null,
-          "target_group_arn": "each.value.target_group.arn",
-          "target_id": "each.value.instance_ip"
+          "target_group_arn": null,
+          "target_id": null
         }
       }
     },


### PR DESCRIPTION
The policy engine is generating warnings indicated that `each` may be a missing term.  This should not happen, we have some code to filter that out here:

https://github.com/snyk/policy-engine/blob/549c2fab2214c0e6f130d355ee3b8fa7d835b552/pkg/hcl_interpreter/term.go#L159

This isn’t triggering because `iterator` is set to the default value (`"each"`), but we represent that as `""`.  This code refactors that file to make `iterator` non-optional.

This changes one regression related to Regula.  This regression was only about the code producing a runtime panic so we don't change that behaviour, and the new `null` value is more correct.