### PR TITLE
[CLOUD-1732] feat: support terraform path.root and path.cwd

### DIFF
--- a/changes/unreleased/Added-20230905-171625.yaml
+++ b/changes/unreleased/Added-20230905-171625.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Support for Terraform path.root and path.cwd
+time: 2023-09-05T17:16:25.739321+01:00

--- a/pkg/hcl_interpreter/hcl_interpreter.go
+++ b/pkg/hcl_interpreter/hcl_interpreter.go
@@ -245,6 +245,15 @@ func (v *Evaluation) evaluate() error {
 
 		vars := v.prepareVariables(name, term)
 		vars = MergeVal(vars, NestVal(LocalName{"path", "module"}, cty.StringVal(moduleMeta.Dir)))
+
+		// While we could pass policy-engine’s actual CWD as path.cwd, but this
+		// would make it awkward to snapshot-test ("golden test"). Arguably, we
+		// can't reasonably predict what a given terraform config expected CWD to be
+		// at runtime - and the Terraform docs recommend using path.module or
+		// path.root for this reason:
+		// https://developer.hashicorp.com/terraform/language/expressions/references#filesystem-and-workspace-info
+		vars = MergeVal(vars, NestVal(LocalName{"path", "cwd"}, cty.StringVal("/stubbed/working/directory")))
+
 		vars = MergeVal(vars, NestVal(LocalName{"terraform", "workspace"}, cty.StringVal("default")))
 
 		val, diags := term.Evaluate(func(expr hcl.Expression, extraVars cty.Value) (cty.Value, hcl.Diagnostics) {

--- a/pkg/hcl_interpreter/hcl_interpreter.go
+++ b/pkg/hcl_interpreter/hcl_interpreter.go
@@ -246,6 +246,11 @@ func (v *Evaluation) evaluate() error {
 		vars := v.prepareVariables(name, term)
 		vars = MergeVal(vars, NestVal(LocalName{"path", "module"}, cty.StringVal(moduleMeta.Dir)))
 
+		rootModule := v.Analysis.Modules[ModuleNameToString(EmptyModuleName)]
+		if rootModule != nil {
+			vars = MergeVal(vars, NestVal(LocalName{"path", "root"}, cty.StringVal(rootModule.Dir)))
+		}
+
 		// While we could pass policy-engine’s actual CWD as path.cwd, but this
 		// would make it awkward to snapshot-test ("golden test"). Arguably, we
 		// can't reasonably predict what a given terraform config expected CWD to be

--- a/pkg/input/golden_test/tf/file.json
+++ b/pkg/input/golden_test/tf/file.json
@@ -14,14 +14,16 @@
         "namespace": "golden_test/tf/file",
         "tags": {
           "file1": "Hello\n",
-          "file2": "Hello\n"
+          "file2": "Hello\n",
+          "stubbedCWD": "/stubbed/working/directory"
         },
         "meta": {},
         "attributes": {
           "force_destroy": true,
           "tags": {
             "file1": "Hello\n",
-            "file2": "Hello\n"
+            "file2": "Hello\n",
+            "stubbedCWD": "/stubbed/working/directory"
           }
         }
       }

--- a/pkg/input/golden_test/tf/file.json
+++ b/pkg/input/golden_test/tf/file.json
@@ -15,6 +15,7 @@
         "tags": {
           "file1": "Hello\n",
           "file2": "Hello\n",
+          "fileAtRoot": "Hello\n",
           "stubbedCWD": "/stubbed/working/directory"
         },
         "meta": {},
@@ -23,7 +24,25 @@
           "tags": {
             "file1": "Hello\n",
             "file2": "Hello\n",
+            "fileAtRoot": "Hello\n",
             "stubbedCWD": "/stubbed/working/directory"
+          }
+        }
+      },
+      "module.child.aws_s3_bucket.trail_bucket": {
+        "id": "module.child.aws_s3_bucket.trail_bucket",
+        "resource_type": "aws_s3_bucket",
+        "namespace": "golden_test/tf/file",
+        "tags": {
+          "fileAtRoot": "Hello\n",
+          "fileInModule": "Hello from a child module\n"
+        },
+        "meta": {},
+        "attributes": {
+          "force_destroy": true,
+          "tags": {
+            "fileAtRoot": "Hello\n",
+            "fileInModule": "Hello from a child module\n"
           }
         }
       }

--- a/pkg/input/golden_test/tf/file.json
+++ b/pkg/input/golden_test/tf/file.json
@@ -12,10 +12,17 @@
         "id": "aws_s3_bucket.trail_bucket",
         "resource_type": "aws_s3_bucket",
         "namespace": "golden_test/tf/file",
+        "tags": {
+          "file1": "Hello\n",
+          "file2": "Hello\n"
+        },
         "meta": {},
         "attributes": {
           "force_destroy": true,
-          "tags": null
+          "tags": {
+            "file1": "Hello\n",
+            "file2": "Hello\n"
+          }
         }
       }
     }

--- a/pkg/input/golden_test/tf/file/child_module/hello_child_module.txt
+++ b/pkg/input/golden_test/tf/file/child_module/hello_child_module.txt
@@ -1,0 +1,1 @@
+Hello from a child module

--- a/pkg/input/golden_test/tf/file/child_module/root_ref.tf
+++ b/pkg/input/golden_test/tf/file/child_module/root_ref.tf
@@ -1,0 +1,21 @@
+// © 2022-2023 Snyk Limited All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+resource "aws_s3_bucket" "trail_bucket" {
+  force_destroy = true
+  tags = {
+    fileInModule = file("${path.module}/hello_child_module.txt")
+    fileAtRoot   = file("${path.root}/hello.txt")
+  }
+}

--- a/pkg/input/golden_test/tf/file/main.tf
+++ b/pkg/input/golden_test/tf/file/main.tf
@@ -15,7 +15,8 @@
 resource "aws_s3_bucket" "trail_bucket" {
   force_destroy = true
   tags = {
-    file1 = file("golden_test/tf/file/hello.txt")
-    file2 = file("${path.module}/hello.txt")
+    file1      = file("golden_test/tf/file/hello.txt")
+    file2      = file("${path.module}/hello.txt")
+    stubbedCWD = path.cwd
   }
 }

--- a/pkg/input/golden_test/tf/file/main.tf
+++ b/pkg/input/golden_test/tf/file/main.tf
@@ -17,6 +17,11 @@ resource "aws_s3_bucket" "trail_bucket" {
   tags = {
     file1      = file("golden_test/tf/file/hello.txt")
     file2      = file("${path.module}/hello.txt")
+    fileAtRoot = file("${path.root}/hello.txt")
     stubbedCWD = path.cwd
   }
+}
+
+module "child" {
+  source = "./child_module"
 }

--- a/pkg/input/golden_test/tf/file/main.tf
+++ b/pkg/input/golden_test/tf/file/main.tf
@@ -15,7 +15,7 @@
 resource "aws_s3_bucket" "trail_bucket" {
   force_destroy = true
   tags = {
-    file1 = file("tf_test/file/hello.txt")
+    file1 = file("golden_test/tf/file/hello.txt")
     file2 = file("${path.module}/hello.txt")
   }
 }


### PR DESCRIPTION


**fix: one golden fixture**

path.module was already supported, but not properly tested due to a
typo.



**feat: support for terraform path.cwd, as a stub**




**feat: support for terraform path.root**

Assumes that the root module is what was passed into policy-engine as a
directory input (or the parent dir of a file input).

