### PR TITLE
fix: remediation advice is not emittted for every resource type

### DIFF
--- a/changes/unreleased/Fixed-20230906-084752.yaml
+++ b/changes/unreleased/Fixed-20230906-084752.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Remediation advice is emitted for every resource type
+time: 2023-09-06T08:47:52.202712+02:00

--- a/pkg/policy/base.go
+++ b/pkg/policy/base.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/open-policy-agent/opa/ast"
+
 	"github.com/snyk/policy-engine/pkg/input"
 	"github.com/snyk/policy-engine/pkg/logging"
 	"github.com/snyk/policy-engine/pkg/models"
@@ -135,9 +136,10 @@ var remediationKeys = map[string]string{
 	input.Arm.Name:            "arm",
 	input.CloudFormation.Name: "cloudformation",
 	input.CloudScan.Name:      "console",
-	input.Kubernetes.Name:     "k8s",
+	input.Kubernetes.Name:     "kubernetes",
 	input.TerraformHCL.Name:   "terraform",
 	input.TerraformPlan.Name:  "terraform",
+	input.TerraformState.Name: "terraform",
 }
 
 type Metadata struct {

--- a/pkg/policy/base_test.go
+++ b/pkg/policy/base_test.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/snyk/policy-engine/pkg/input"
 )
 
 // TestReferencesFor tests that we obtain only the expected references.
@@ -60,4 +62,24 @@ func TestReferencesFor(t *testing.T) {
 			},
 		},
 	)
+}
+
+func TestRemediationFor(t *testing.T) {
+	m := Metadata{
+		Remediation: map[string]string{
+			"arm":            "remediation for arm",
+			"cloudformation": "remediation for cloudformation",
+			"console":        "remediation for console",
+			"kubernetes":     "remediation for kubernetes",
+			"terraform":      "remediation for terraform",
+		},
+	}
+
+	assert.Equal(t, m.RemediationFor(input.Arm.Name), "remediation for arm")
+	assert.Equal(t, m.RemediationFor(input.CloudFormation.Name), "remediation for cloudformation")
+	assert.Equal(t, m.RemediationFor(input.CloudScan.Name), "remediation for console")
+	assert.Equal(t, m.RemediationFor(input.Kubernetes.Name), "remediation for kubernetes")
+	assert.Equal(t, m.RemediationFor(input.TerraformHCL.Name), "remediation for terraform")
+	assert.Equal(t, m.RemediationFor(input.TerraformState.Name), "remediation for terraform")
+	assert.Equal(t, m.RemediationFor(input.TerraformPlan.Name), "remediation for terraform")
 }


### PR DESCRIPTION
The remediation advice in opa-rules is written under the `kubernetes` key in the metadata, not under `k8s`. This PR fixes the key the PE uses to read the default metadata for Kubernetes inputs, and additionally adds a key for Terraform state inputs which, in my opinion, was incorrectly missing.