### PR TITLE
docs: updated key in remediation object for kubernetes

### DIFF
--- a/changes/unreleased/Changed-20230906-115302.yaml
+++ b/changes/unreleased/Changed-20230906-115302.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: 'Documentation around kubernetes key in remediation object '
+time: 2023-09-06T11:53:02.051081+01:00

--- a/docs/policy_spec.md
+++ b/docs/policy_spec.md
@@ -267,7 +267,7 @@ mapping:
 | `tf_plan`    | `terraform`                 |
 | `cfn`        | `cloudformation`            |
 | `cloud_scan` | `console`                   |
-| `k8s`        | `k8s`                       |
+| `k8s`        | `kubernetes`                       |
 | `arm`        | `arm`                       |
 
 Policies can also bypass this behavior by returning a `remediation` string in the


### PR DESCRIPTION
Updated docs as advised [here](https://github.com/snyk/policy-engine/pull/262#issuecomment-1707990793)