### PR TITLE
Bump version to v0.29.2

### DIFF
--- a/.changie.yaml
+++ b/.changie.yaml
@@ -6,6 +6,9 @@ versionExt: md
 versionFormat: '## {{.Version}} - {{.Time.Format "2006-01-02"}}'
 kindFormat: '### {{.Kind}}'
 changeFormat: '* {{.Body}}'
+newlines:
+  afterChangelogVersion: 1
+  beforeChangelogVersion: 1
 kinds:
 - label: Added
 - label: Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # CHANGELOG
 
 
+## v0.29.2 - 2023-09-06
+### Changed
+* tweak error message for EvaluationError in hcl_interpreter
+### Fixed
+* non-string variables defaulting to string instead of null
+* issue parsing remote terraform module register
+* add source code location to missing term errors
+* remove spurious warnings for default iterator
+* Remediation advice is emitted for every resource type
+### Updated
+* clarify that custom metadata fields are ignored
 
 ## v0.29.1 - 2023-08-21
 ### Fixed

--- a/changes/unreleased/Changed-20230823-153728.yaml
+++ b/changes/unreleased/Changed-20230823-153728.yaml
@@ -1,3 +1,0 @@
-kind: Changed
-body: tweak error message for EvaluationError in hcl_interpreter
-time: 2023-08-23T15:37:28.417411656+02:00

--- a/changes/unreleased/Fixed-20230901-173949.yaml
+++ b/changes/unreleased/Fixed-20230901-173949.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: non-string variables defaulting to string instead of null
-time: 2023-09-01T17:39:49.890115566+02:00

--- a/changes/unreleased/Fixed-20230904-132306.yaml
+++ b/changes/unreleased/Fixed-20230904-132306.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: issue parsing remote terraform module register
-time: 2023-09-04T13:23:06.274955918+02:00

--- a/changes/unreleased/Fixed-20230904-141653.yaml
+++ b/changes/unreleased/Fixed-20230904-141653.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: add source code location to missing term errors
-time: 2023-09-04T14:16:53.074091429+02:00

--- a/changes/unreleased/Fixed-20230904-161021.yaml
+++ b/changes/unreleased/Fixed-20230904-161021.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: remove spurious warnings for default iterator
-time: 2023-09-04T16:10:21.128028096+02:00

--- a/changes/unreleased/Fixed-20230906-084752.yaml
+++ b/changes/unreleased/Fixed-20230906-084752.yaml
@@ -1,3 +1,0 @@
-kind: Fixed
-body: Remediation advice is emitted for every resource type
-time: 2023-09-06T08:47:52.202712+02:00

--- a/changes/unreleased/Updated-20230822-115049.yaml
+++ b/changes/unreleased/Updated-20230822-115049.yaml
@@ -1,3 +1,0 @@
-kind: Updated
-body: clarify that custom metadata fields are ignored
-time: 2023-08-22T11:50:49.687803+02:00

--- a/changes/v0.29.2.md
+++ b/changes/v0.29.2.md
@@ -1,0 +1,11 @@
+## v0.29.2 - 2023-09-06
+### Changed
+* tweak error message for EvaluationError in hcl_interpreter
+### Fixed
+* non-string variables defaulting to string instead of null
+* issue parsing remote terraform module register
+* add source code location to missing term errors
+* remove spurious warnings for default iterator
+* Remediation advice is emitted for every resource type
+### Updated
+* clarify that custom metadata fields are ignored


### PR DESCRIPTION
I followed the instructions in the developers' documentation, but the lastest version of Changie (1.13.0) requires a bit of extra configuration to generate a non-malformed changelog with the same amount of newlines as you did before. Sorry for the extra noise!