### PR TITLE
fix: remove spurious warnings for static missing terms

### DIFF
--- a/changes/unreleased/Fixed-20230906-141016.yaml
+++ b/changes/unreleased/Fixed-20230906-141016.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: remove spurious warning for static missing terms
+time: 2023-09-06T14:10:16.390032812+02:00

--- a/pkg/hcl_interpreter/names.go
+++ b/pkg/hcl_interpreter/names.go
@@ -75,10 +75,30 @@ func ChildModuleName(moduleName ModuleName, childName string) ModuleName {
 	return out
 }
 
-type LocalName = []string
+type LocalName []string
+
+var (
+    // Supported fixed paths can be checked using Equals.
+	PathModuleName         = LocalName{"path", "module"}
+	PathRootName           = LocalName{"path", "root"}
+	PathCwdName            = LocalName{"path", "cwd"}
+	TerraformWorkspaceName = LocalName{"terraform", "workspace"}
+)
 
 func LocalNameToString(name LocalName) string {
 	return strings.Join(name, ".")
+}
+
+func (name LocalName) Equals(other LocalName) bool {
+	if len(name) != len(other) {
+		return false
+	}
+	for i := range name {
+		if name[i] != other[i] {
+			return false
+		}
+	}
+	return true
 }
 
 type FullName struct {


### PR DESCRIPTION
We support the following "static" terms:

- `path.module`
- `path.root`
- `path.cwd`
- `terraform.workspace`

However, we were injecting them into the scope in a hardcoded way for every term, rather than using the proper dependency system.  This caused us to emit misleading "missing term" warnings.