### PR TITLE
fix: source locations for count/for_each resources in tf loader

### DIFF
--- a/changes/unreleased/Fixed-20230928-234826.yaml
+++ b/changes/unreleased/Fixed-20230928-234826.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: source locations for count/for_each resources in tf loader
+time: 2023-09-28T23:48:26.408514+02:00

--- a/pkg/hcl_interpreter/source_locations.go
+++ b/pkg/hcl_interpreter/source_locations.go
@@ -16,14 +16,23 @@ package hcl_interpreter
 
 import (
 	"fmt"
+	"regexp"
 
 	"github.com/hashicorp/hcl/v2"
 )
+
+// Utility to strip out "[x]" parts from resource IDs.
+var resourceIdBracketPattern = regexp.MustCompile(`\[[^[*]\]`)
 
 func (v *Evaluation) Location(
 	resourceId string,
 	path []interface{},
 ) []hcl.Range {
+	// If we receive a resourceId such as `aws_s3_bucket.my_bucket[0]`, we want
+	// to strip out any `[0]` part, since the source code syntax does not have
+	// any concept of these "multi"-resources.
+	resourceId = resourceIdBracketPattern.ReplaceAllLiteralString(resourceId, "")
+
 	// Find resource location.
 	resource, ok := v.Analysis.Resources[resourceId]
 	name, _ := StringToFullName(resourceId)

--- a/pkg/input/golden_location_test.go
+++ b/pkg/input/golden_location_test.go
@@ -367,6 +367,40 @@ var goldenLocationTests = []goldenLocationTest{
 			},
 		},
 	},
+	{
+		directory: "golden_test/tf/count-simple",
+		cases: []goldenLocationTestCase{
+			{
+				path: []interface{}{
+					"golden_test/tf/count-simple",
+					"aws_s3_bucket",
+					"aws_s3_bucket.example[0]",
+				},
+				expected: LocationStack{
+					{
+						Path: "main.tf",
+						Line: 15,
+						Col:  1,
+					},
+				},
+			},
+			{
+				path: []interface{}{
+					"golden_test/tf/count-simple",
+					"aws_s3_bucket",
+					"aws_s3_bucket.example[0]",
+					"bucket_prefix",
+				},
+				expected: LocationStack{
+					{
+						Path: "main.tf",
+						Line: 17,
+						Col:  3,
+					},
+				},
+			},
+		},
+	},
 }
 
 // Tests for attribute locations.  These use the same input files as the


### PR DESCRIPTION
Resources that have `count` or `for_each` set will have resource IDs of the shape `resource_type.resource_name[key]`.  When we try to resolve the source code locations of these, we want to strip out the `[key]` part, since the source code only has the single resource.