### PR TITLE
fix: resource schema mixup when count/for_each fails to evaluate

### DIFF
--- a/changes/unreleased/Fixed-20230928-235239.yaml
+++ b/changes/unreleased/Fixed-20230928-235239.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: "fix: resource schema mixup when count/for_each fails to evaluate"
+time: 2023-09-28T23:52:39.422983+02:00

--- a/pkg/hcl_interpreter/term.go
+++ b/pkg/hcl_interpreter/term.go
@@ -279,14 +279,14 @@ func (t Term) Evaluate(
 			}
 		}
 
-		arr := []cty.Value{}
+		arr := make([]cty.Value, count)
 		for i := int64(0); i < count; i++ {
 			val, diags := t.evaluateExpr(func(e hcl.Expression, v cty.Value) (cty.Value, hcl.Diagnostics) {
 				v = MergeVal(v, NestVal(LocalName{"count", "index"}, cty.NumberIntVal(i)))
 				return evalExpr(e, v)
 			})
 			diagnostics = append(diagnostics, diags...)
-			arr = append(arr, val)
+			arr[i] = val
 		}
 		return cty.TupleVal(arr), diagnostics
 	}

--- a/pkg/hcl_interpreter/term.go
+++ b/pkg/hcl_interpreter/term.go
@@ -274,10 +274,8 @@ func (t Term) Evaluate(
 		// so we can check it for misconfigurations.
 		count := int64(1)
 		if !countVal.IsNull() && countVal.IsKnown() && countVal.Type() == cty.Number {
-			big := countVal.AsBigFloat()
-			if big.IsInt() {
-				n, _ := big.Int64()
-				count = n
+			if big := countVal.AsBigFloat(); big.IsInt() {
+				count, _ = big.Int64()
 			}
 		}
 

--- a/pkg/input/golden_test/tf/count-err.json
+++ b/pkg/input/golden_test/tf/count-err.json
@@ -1,0 +1,26 @@
+{
+  "format": "",
+  "format_version": "",
+  "input_type": "tf_hcl",
+  "environment_provider": "iac",
+  "meta": {
+    "filepath": "golden_test/tf/count-err/main.tf"
+  },
+  "resources": {
+    "aws_s3_bucket": {
+      "aws_s3_bucket.count_bucket[0]": {
+        "id": "aws_s3_bucket.count_bucket[0]",
+        "resource_type": "aws_s3_bucket",
+        "namespace": "golden_test/tf/count-err/main.tf",
+        "meta": {},
+        "attributes": {
+          "bucket_prefix": "some_count",
+          "count": "var.create_bucket"
+        }
+      }
+    }
+  },
+  "scope": {
+    "filepath": "golden_test/tf/count-err/main.tf"
+  }
+}

--- a/pkg/input/golden_test/tf/count-err.json
+++ b/pkg/input/golden_test/tf/count-err.json
@@ -15,7 +15,7 @@
         "meta": {},
         "attributes": {
           "bucket_prefix": "some_count",
-          "count": "var.create_bucket"
+          "count": null
         }
       }
     }

--- a/pkg/input/golden_test/tf/count-err/main.tf
+++ b/pkg/input/golden_test/tf/count-err/main.tf
@@ -1,0 +1,9 @@
+resource "aws_s3_bucket" "count_bucket" {
+  count         = var.create_bucket
+  bucket_prefix = "some_count"
+}
+
+resource "aws_s3_bucket" "for_each_bucket" {
+  for_each      = var.create_bucket ? {} : {"key": "value"}
+  bucket_prefix = "some_for_each"
+}

--- a/pkg/input/golden_test/tf/count-err/main.tf
+++ b/pkg/input/golden_test/tf/count-err/main.tf
@@ -1,9 +1,9 @@
 resource "aws_s3_bucket" "count_bucket" {
-  count         = var.create_bucket
+  count         = var.create_bucket ? 1 : 0
   bucket_prefix = "some_count"
 }
 
 resource "aws_s3_bucket" "for_each_bucket" {
-  for_each      = var.create_bucket ? {} : {"key": "value"}
+  for_each      = var.create_bucket ? {"key": "value"} : {}
   bucket_prefix = "some_for_each"
 }

--- a/pkg/input/golden_test/tf/regula-issue-397.json
+++ b/pkg/input/golden_test/tf/regula-issue-397.json
@@ -69,29 +69,6 @@
         }
       }
     },
-    "aws_lb_target_group_attachment": {
-      "aws_lb_target_group_attachment.msk_tgr_attachment[for_each]": {
-        "id": "aws_lb_target_group_attachment.msk_tgr_attachment[for_each]",
-        "resource_type": "aws_lb_target_group_attachment",
-        "namespace": "golden_test/tf/regula-issue-397/main.tf",
-        "meta": {},
-        "attributes": {}
-      },
-      "aws_lb_target_group_attachment.msk_tgr_attachment[target_group_arn]": {
-        "id": "aws_lb_target_group_attachment.msk_tgr_attachment[target_group_arn]",
-        "resource_type": "aws_lb_target_group_attachment",
-        "namespace": "golden_test/tf/regula-issue-397/main.tf",
-        "meta": {},
-        "attributes": {}
-      },
-      "aws_lb_target_group_attachment.msk_tgr_attachment[target_id]": {
-        "id": "aws_lb_target_group_attachment.msk_tgr_attachment[target_id]",
-        "resource_type": "aws_lb_target_group_attachment",
-        "namespace": "golden_test/tf/regula-issue-397/main.tf",
-        "meta": {},
-        "attributes": {}
-      }
-    },
     "data.aws_msk_broker_nodes": {
       "data.aws_msk_broker_nodes.msk_nodes": {
         "id": "data.aws_msk_broker_nodes.msk_nodes",


### PR DESCRIPTION
If we have some terraform code like:

    resource "aws_s3_bucket" "count_bucket" {
      count         = var.create_bucket ? 1 : 0
      bucket_prefix = "some_count"
    }

And `var.create_bucket` is not set, we produce some truly bizarre resources (reproduced with `policy-engine fixture` here):

    {
      "resources": {
        "aws_s3_bucket": {
          "aws_s3_bucket.count_bucket[bucket_prefix]": {
            "resource_type": "aws_s3_bucket",
            "attributes": {},
            ...
          },
          "aws_s3_bucket.count_bucket[count]": {
            "resource_type": "aws_s3_bucket",
            "attributes": {},
            ...
          }
        }
      },
      ...
    }

The `attributes` in the resources are empty, and somehow they end up as part of the resource IDs!  This affects `for_each` as well as `count`.

This is caused by the following sequence of events:

1.  `var.create_bucket` is not specified; since the user is scanning the terraform code without passing in the necessary variables.
2.  In `func (t Term) Evaluate(...)` in `term.go`, the `count` attribute fails to evaluate for this reason.
3.  We fall back to creating a single resource instead.
4.  In `func (v *Evaluation) prepareResource(...)` in `hcl_interpreter.go`, we read `resource.Multiple == true`, and try to parse this single resource as a multi resource.
5.  This causes a situation where we mistake the object containing multiple resources with the object containing multiple attributes.

This PR fixes this by changing step (3).

 -  If the evaluation of `count` fails, we use `count = 1` more consistently.
 -  If the evaluation of `for_each` fails, we use an empty object.

This fixes the `regula-issue-397` testcase, where this problem was appearing as well.  This is a regression that was added to ensure we don't panic, so we're okay with changing the output.