### PR TITLE
fix: get rid of capnslog import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # CHANGELOG
 
 
+## v0.30.6 - 2024-01-12
+### Fixed
+* `capnslog` is not imported anymore, removing a logging-sideeffect.
 
 ## v0.30.5 - 2023-11-23
 ### Fixed

--- a/changes/unreleased/Fixed-20240112-163758.yaml
+++ b/changes/unreleased/Fixed-20240112-163758.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: '`capnslog` is not imported anymore, removing a logging-sideffect'
+time: 2024-01-12T16:37:58.888303+01:00

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/apparentlymart/go-versions v1.0.1
 	github.com/bmatcuk/doublestar v1.3.4
 	github.com/bmatcuk/doublestar/v4 v4.0.2
-	github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f
 	github.com/davecgh/go-spew v1.1.1
 	github.com/google/go-cmp v0.5.9
 	github.com/google/go-querystring v1.1.0
@@ -57,7 +56,6 @@ require (
 	github.com/apparentlymart/go-textseg/v13 v13.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.44.122 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
-	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf // indirect
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -238,11 +238,7 @@ github.com/cncf/xds/go v0.0.0-20210805033703-aa0b78936158/go.mod h1:eXthEFrGJvWH
 github.com/cncf/xds/go v0.0.0-20210922020428-25de7278fc84/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211001041855-01bcc9b48dfe/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
 github.com/cncf/xds/go v0.0.0-20211011173535-cb28da3451f1/go.mod h1:eXthEFrGJvWHgFFCl3hGmgk+/aYT6PnTQLykKQRLhEs=
-github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
-github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
-github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
-github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/internal/terraform/logging/logging.go
+++ b/pkg/internal/terraform/logging/logging.go
@@ -8,11 +8,6 @@ import (
 	"strings"
 	"syscall"
 
-	// go.etcd.io/etcd imports capnslog, which calls log.SetOutput in its
-	// init() function, so importing it here means that our log.SetOutput
-	// wins. this is fixed in coreos v3.5, which is not released yet. See
-	// https://github.com/etcd-io/etcd/issues/12498 for more information.
-	_ "github.com/coreos/pkg/capnslog"
 	"github.com/hashicorp/go-hclog"
 )
 


### PR DESCRIPTION
This commit removes the anonymous import of the
`github.com/coreos/pkg/capnslog` package, which breaks / changes logging in subtle ways.

Importing that package has a side-effect due to the `capnslog`'s `init` function, which sets a global logger.
By blank-importing it, we "fixed" the order of package-loading so that this does not cause any issues.

However, for other services depending on policy-engine (like issue-policies) this side-effect still exists and has to be handled in [weird ways](https://github.com/snyk/issue-policies/blob/fdab20f0b2984340fd78638cd2b1482097c73e61/internal/core/log/log.go#L12).

It looks like we've upgraded and changed our code enough to get rid of that import though since this was added - compiling policy-engine and checking the imported modules shows no sign of the `github.com/coreos/pkg` module anymore:

```
$ # before this change:
$ go version -m ./policy-engine | rg 'coreos'
dep     github.com/coreos/go-systemd    v0.0.0-20191104093116-d3cd4ed1dbcf      h1:iW4rZ826su+pqaw19uhpSCzhj44qo35pNgKFGqzDKkU=
dep     github.com/coreos/pkg   v0.0.0-20180928190104-399ea9e2e55f      h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
$ # with this change:
$ go version -m ./policy-engine | rg 'coreos'
$
```

This means that upstream users can also get rid of code handling this annoying side effect.

[NARW-2842]

[NARW-2842]: https://snyksec.atlassian.net/browse/NARW-2842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ