### PR TITLE
fix: panic in forEachResult.add

### DIFF
--- a/changes/unreleased/Fixed-20240322-114459.yaml
+++ b/changes/unreleased/Fixed-20240322-114459.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: panic in forEachResult.add
+time: 2024-03-22T11:44:59.264406+02:00

--- a/pkg/hcl_interpreter/term.go
+++ b/pkg/hcl_interpreter/term.go
@@ -246,11 +246,13 @@ type forEachResult struct {
 
 func (acc *forEachResult) add(key cty.Value, val cty.Value) {
 	if !acc.isTuple && key.Type() == cty.String {
-		if acc.object == nil {
-			acc.object = map[string]cty.Value{}
+		if !key.IsNull() && key.IsKnown() {
+			if acc.object == nil {
+				acc.object = map[string]cty.Value{}
+			}
+			acc.object[key.AsString()] = val
+			acc.tuple = append(acc.tuple, val)
 		}
-		acc.object[key.AsString()] = val
-		acc.tuple = append(acc.tuple, val)
 	} else {
 		acc.isTuple = true
 		acc.tuple = append(acc.tuple, val)


### PR DESCRIPTION
We have this panic in CCPE:
```
value is null

goroutine 95 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:24 +0x5e
main.(*messageHandler).handleMessage.func1()
	/srv/app/cmd/import-consumer/main.go:279 +0xd7
panic({0x1b3a000?, 0x23361c0?})
	/usr/local/go/src/runtime/panic.go:914 +0x21f
github.com/zclconf/go-cty/cty.Value.AsString({{{0x2348f98?, 0xc000014cc1?}}, {0x0?, 0x0?}})
	/root/go/pkg/mod/github.com/zclconf/go-cty@v1.14.1/cty/value_ops.go:1390 +0x10b
github.com/snyk/policy-engine/pkg/hcl_interpreter.(*forEachResult).add(0xc00a3f1f88, {{{0x2348f98?, 0xc000014cc1?}}, {0x0?, 0x0?}}, {{{0x2348c50?, 0xc00b75c770?}}, {0x1bca620?, 0xc00b763350?}})
	/root/go/pkg/mod/github.com/snyk/policy-engine@v0.30.7/pkg/hcl_interpreter/term.go:252 +0x14d
github.com/snyk/policy-engine/pkg/hcl_interpreter.Term.Evaluate({0x0, 0xc00b69b710, 0xc00b69b740, 0x0, 0xc00b684d20, {0x1de2e74, 0x4}}, 0xc00b7626c0)
	/root/go/pkg/mod/github.com/snyk/policy-engine@v0.30.7/pkg/hcl_interpreter/term.go:323 +0xba5
github.com/snyk/policy-engine/pkg/hcl_interpreter.(*Evaluation).evaluate(0xc00b709400)
	/root/go/pkg/mod/github.com/snyk/policy-engine@v0.30.7/pkg/hcl_interpreter/hcl_interpreter.go:290 +0x3a7
github.com/snyk/policy-engine/pkg/hcl_interpreter.EvaluateAnalysis(0xc00b679e40)
	/root/go/pkg/mod/github.com/snyk/policy-engine@v0.30.7/pkg/hcl_interpreter/hcl_interpreter.go:242 +0x245
github.com/snyk/policy-engine/pkg/input.newHclConfiguration(0xc0089d3380)
	/root/go/pkg/mod/github.com/snyk/policy-engine@v0.30.7/pkg/input/tf.go:94 +0x2f
github.com/snyk/policy-engine/pkg/input.(*TfDetector).DetectDirectory(0x0?, 0xc00b2cfd80, {0x40?, {0x0?, 0x0?, 0x10?}})
	/root/go/pkg/mod/github.com/snyk/policy-engine@v0.30.7/pkg/input/tf.go:83 +0x285
github.com/snyk/snyk-iac-test/pkg/engine.errorsHandlingDetector.DetectDirectory({{0x2341430?, 0x32e26c0?}}, 0x8?, {0x0?, {0x0?, 0x2?, 0x6?}})
	/root/go/pkg/mod/github.com/snyk/snyk-iac-test@v0.51.1/pkg/engine/detector.go:79 +0x34
github.com/snyk/snyk-iac-test/pkg/engine.(*detector).DetectDirectory(0x0?, 0x0?, {0x0?, {0x0?, 0xc005cc6070?, 0xc005cc6290?}})
	/root/go/pkg/mod/github.com/snyk/snyk-iac-test@v0.51.1/pkg/engine/detector.go:155 +0xa9
github.com/snyk/policy-engine/pkg/input.(*Directory).DetectType(0x1bc9480?, {0x23413b8?, 0xc0035e3b30?}, {0x36?, {0x0?, 0x1?, 0x0?}})
	/root/go/pkg/mod/github.com/snyk/policy-engine@v0.30.7/pkg/input/detector.go:133 +0x34
github.com/snyk/policy-engine/pkg/input.(*Loader).Load(0xc00a3f3138, {0x2341390, 0xc00b2cfd80}, {0x0?, {0x0?, 0xc00b238720?, 0x23413b8?}})
	/root/go/pkg/mod/github.com/snyk/policy-engine@v0.30.7/pkg/input/loader.go:73 +0xc2
github.com/snyk/snyk-iac-test/pkg/engine.(*scanner).load(0xc00a3f3118, {0x2341390, 0xc00b2cfd80})
	/root/go/pkg/mod/github.com/snyk/snyk-iac-test@v0.51.1/pkg/engine/scanner.go:167 +0x9c
github.com/snyk/snyk-iac-test/pkg/engine.(*scanner).walkDirectory.func1({0x2341390, 0xc00b2cfd80}, 0x2341390?)
	/root/go/pkg/mod/github.com/snyk/snyk-iac-test@v0.51.1/pkg/engine/scanner.go:132 +0x88
github.com/snyk/policy-engine/pkg/input.(*Directory).walk(0x2341390?, 0xc00a3f2ba8, 0x3)
	/root/go/pkg/mod/github.com/snyk/policy-engine@v0.30.7/pkg/input/detector.go:171 +0x9a
github.com/snyk/policy-engine/pkg/input.(*Directory).walk(0x2341390?, 0xc00a3f2ba8, 0x2)
	/root/go/pkg/mod/github.com/snyk/policy-engine@v0.30.7/pkg/input/detector.go:179 +0xdb
github.com/snyk/policy-engine/pkg/input.(*Directory).walk(0x2341390?, 0xc00a3f2ba8, 0x1)
	/root/go/pkg/mod/github.com/snyk/policy-engine@v0.30.7/pkg/input/detector.go:179 +0xdb
github.com/snyk/policy-engine/pkg/input.(*Directory).walk(0xc0052e7118?, 0xc00a3f2ba8, 0x0)
	/root/go/pkg/mod/github.com/snyk/policy-engine@v0.30.7/pkg/input/detector.go:179 +0xdb
github.com/snyk/policy-engine/pkg/input.(*Directory).Walk(...)
	/root/go/pkg/mod/github.com/snyk/policy-engine@v0.30.7/pkg/input/detector.go:190
github.com/snyk/snyk-iac-test/pkg/engine.(*scanner).walkDirectory(0xc00a3f3118, {0xc003761450, 0xf})
	/root/go/pkg/mod/github.com/snyk/snyk-iac-test@v0.51.1/pkg/engine/scanner.go:135 +0xda
github.com/snyk/snyk-iac-test/pkg/engine.(*scanner).loadDirectory(0xc00a3f3118, {0xc003761450, 0xf})
	/root/go/pkg/mod/github.com/snyk/snyk-iac-test@v0.51.1/pkg/engine/scanner.go:90 +0x5a
github.com/snyk/snyk-iac-test/pkg/engine.(*scanner).loadPath(0xc0052e7118, {0xc003761450, 0xf})
	/root/go/pkg/mod/github.com/snyk/snyk-iac-test@v0.51.1/pkg/engine/scanner.go:80 +0x185
github.com/snyk/snyk-iac-test/pkg/engine.(*scanner).loadPaths(0xc00a3f3118, {0xc005606000?, 0x1, 0x0?})
	/root/go/pkg/mod/github.com/snyk/snyk-iac-test@v0.51.1/pkg/engine/scanner.go:59 +0x55
github.com/snyk/snyk-iac-test/pkg/engine.(*scanner).scan(0xc00a3f3118, {0xc005606000, 0x1, 0x1})
	/root/go/pkg/mod/github.com/snyk/snyk-iac-test@v0.51.1/pkg/engine/scanner.go:26 +0x115
github.com/snyk/snyk-iac-test/pkg/engine.(*Engine).LoadInput(0x4ad3eb?, {{0x2352520, 0x32e26c0}, {0xc005606000, 0x1, 0x1}, {0x0, 0x0, 0x0}, {0x0, ...}, ...})
	/root/go/pkg/mod/github.com/snyk/snyk-iac-test@v0.51.1/pkg/engine/engine.go:86 +0xf8
github.com/snyk/snyk-iac-test/pkg/engine.(*Engine).Run(0xc0000c6460, {0x2348588, 0xc00374ef60}, {{0x2352520, 0x32e26c0}, {0xc005606000, 0x1, 0x1}, {0x0, 0x0, ...}, ...})
	/root/go/pkg/mod/github.com/snyk/snyk-iac-test@v0.51.1/pkg/engine/engine.go:67 +0x58
github.com/snyk/cloud-config-policy-engine/cmd/import-consumer/importer.(*Importer).Import(0xc0006ac700, {0x2348588, 0xc00374ef60}, {0xc00606a0c0, 0xb6}, {0xc003512750, 0x24}, {0xc0035127b0, 0x24})
	/srv/app/cmd/import-consumer/importer/importer.go:174 +0x566
main.(*messageHandler).handleMessage(0xc0005b8240, {0x23485c0, 0xc0005f0140}, 0xc002c46240)
	/srv/app/cmd/import-consumer/main.go:283 +0x7ae
github.com/snyk/cloud-config-policy-engine/internal/core/kafka.(*Consumer).consumeMessage(0xc000336000, {0x23485c0, 0xc0005f0140}, 0x1?)
	/srv/app/internal/core/kafka/consumer.go:172 +0x71
github.com/snyk/cloud-config-policy-engine/internal/core/kafka.(*Consumer).consumeEvents(0xc000336000, {0x23485c0, 0xc0005f0140})
	/srv/app/internal/core/kafka/consumer.go:158 +0x151
github.com/snyk/cloud-config-policy-engine/internal/core/kafka.(*Consumer).Run.func2()
	/srv/app/internal/core/kafka/consumer.go:116 +0x1f
golang.org/x/sync/errgroup.(*Group).Go.func1()
	/root/go/pkg/mod/golang.org/x/sync@v0.6.0/errgroup/errgroup.go:78 +0x56
created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 118
	/root/go/pkg/mod/golang.org/x/sync@v0.6.0/errgroup/errgroup.go:75 +0x96
```

This PR should fix this type of panic.

[Jira ticket IAC-2840](https://snyksec.atlassian.net/browse/IAC-2840)

