### PR TITLE
fix: tfplan filter refrences [IAC-2907]

### DIFF
--- a/changes/unreleased/Fixed-20240329-210746.yaml
+++ b/changes/unreleased/Fixed-20240329-210746.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Filtering tfplan references to properly consider counts
+time: 2024-03-29T21:07:46.093861+02:00

--- a/pkg/input/golden_test/tfplan/count-02.json
+++ b/pkg/input/golden_test/tfplan/count-02.json
@@ -1,0 +1,175 @@
+{
+  "format": "",
+  "format_version": "",
+  "input_type": "tf_plan",
+  "environment_provider": "iac",
+  "meta": {
+    "filepath": "golden_test/tfplan/count-02/plan.json"
+  },
+  "resources": {
+    "aws_s3_bucket": {
+      "aws_s3_bucket.logbucket1": {
+        "id": "aws_s3_bucket.logbucket1",
+        "resource_type": "aws_s3_bucket",
+        "namespace": "golden_test/tfplan/count-02/plan.json",
+        "meta": {
+          "region": "us-west-1",
+          "terraform": {
+            "provider_config": {
+              "region": "us-west-1"
+            }
+          },
+          "tfplan": {
+            "resource_actions": [
+              "create"
+            ]
+          }
+        },
+        "attributes": {
+          "bucket": "logbucket1-mtu721uc",
+          "force_destroy": true,
+          "tags": null,
+          "timeouts": null
+        }
+      },
+      "aws_s3_bucket.validbucket1[0]": {
+        "id": "aws_s3_bucket.validbucket1[0]",
+        "resource_type": "aws_s3_bucket",
+        "namespace": "golden_test/tfplan/count-02/plan.json",
+        "meta": {
+          "region": "us-west-1",
+          "terraform": {
+            "provider_config": {
+              "region": "us-west-1"
+            }
+          },
+          "tfplan": {
+            "resource_actions": [
+              "create"
+            ]
+          }
+        },
+        "attributes": {
+          "bucket": "validbucket1-mtu721uc",
+          "force_destroy": true,
+          "logging": [
+            {
+              "target_bucket": "aws_s3_bucket.logbucket1",
+              "target_prefix": "log/"
+            }
+          ],
+          "tags": null,
+          "timeouts": null
+        }
+      },
+      "aws_s3_bucket.validbucket2[0]": {
+        "id": "aws_s3_bucket.validbucket2[0]",
+        "resource_type": "aws_s3_bucket",
+        "namespace": "golden_test/tfplan/count-02/plan.json",
+        "meta": {
+          "region": "us-west-1",
+          "terraform": {
+            "provider_config": {
+              "region": "us-west-1"
+            }
+          },
+          "tfplan": {
+            "resource_actions": [
+              "create"
+            ]
+          }
+        },
+        "attributes": {
+          "bucket": "validbucket2-mtu721uc",
+          "force_destroy": true,
+          "tags": null,
+          "timeouts": null
+        }
+      }
+    },
+    "aws_s3_bucket_acl": {
+      "aws_s3_bucket_acl.acl1": {
+        "id": "aws_s3_bucket_acl.acl1",
+        "resource_type": "aws_s3_bucket_acl",
+        "namespace": "golden_test/tfplan/count-02/plan.json",
+        "meta": {
+          "region": "us-west-1",
+          "terraform": {
+            "provider_config": {
+              "region": "us-west-1"
+            }
+          },
+          "tfplan": {
+            "resource_actions": [
+              "create"
+            ]
+          }
+        },
+        "attributes": {
+          "acl": "log-delivery-write",
+          "bucket": "aws_s3_bucket.logbucket1",
+          "expected_bucket_owner": null
+        }
+      }
+    },
+    "aws_s3_bucket_logging": {
+      "aws_s3_bucket_logging.s3_bucket_log[0]": {
+        "id": "aws_s3_bucket_logging.s3_bucket_log[0]",
+        "resource_type": "aws_s3_bucket_logging",
+        "namespace": "golden_test/tfplan/count-02/plan.json",
+        "meta": {
+          "region": "us-west-1",
+          "terraform": {
+            "provider_config": {
+              "region": "us-west-1"
+            }
+          },
+          "tfplan": {
+            "resource_actions": [
+              "create"
+            ]
+          }
+        },
+        "attributes": {
+          "bucket": "aws_s3_bucket.validbucket2[0]",
+          "expected_bucket_owner": null,
+          "target_bucket": "aws_s3_bucket.logbucket1",
+          "target_grant": [],
+          "target_object_key_format": [],
+          "target_prefix": ""
+        }
+      }
+    },
+    "aws_s3_bucket_ownership_controls": {
+      "aws_s3_bucket_ownership_controls.logbucket1-acl-controls": {
+        "id": "aws_s3_bucket_ownership_controls.logbucket1-acl-controls",
+        "resource_type": "aws_s3_bucket_ownership_controls",
+        "namespace": "golden_test/tfplan/count-02/plan.json",
+        "meta": {
+          "region": "us-west-1",
+          "terraform": {
+            "provider_config": {
+              "region": "us-west-1"
+            }
+          },
+          "tfplan": {
+            "resource_actions": [
+              "create"
+            ]
+          }
+        },
+        "attributes": {
+          "bucket": "aws_s3_bucket.logbucket1",
+          "rule": [
+            {
+              "object_ownership": "BucketOwnerPreferred"
+            }
+          ]
+        }
+      }
+    }
+  },
+  "scope": {
+    "filepath": "golden_test/tfplan/count-02/plan.json"
+  }
+}

--- a/pkg/input/golden_test/tfplan/count-02/plan.json
+++ b/pkg/input/golden_test/tfplan/count-02/plan.json
@@ -1,0 +1,511 @@
+{
+  "format_version": "1.1",
+  "terraform_version": "1.3.7",
+  "variables": { "create_bucket": { "value": true } },
+  "planned_values": {
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_s3_bucket.logbucket1",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "logbucket1",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "bucket": "logbucket1-mtu721uc",
+            "force_destroy": true,
+            "tags": null,
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "cors_rule": [],
+            "grant": [],
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "replication_configuration": [],
+            "server_side_encryption_configuration": [],
+            "tags_all": {},
+            "versioning": [],
+            "website": []
+          }
+        },
+        {
+          "address": "aws_s3_bucket.validbucket1[0]",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "validbucket1",
+          "index": 0,
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "bucket": "validbucket1-mtu721uc",
+            "force_destroy": true,
+            "logging": [{ "target_prefix": "log/" }],
+            "tags": null,
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "cors_rule": [],
+            "grant": [],
+            "lifecycle_rule": [],
+            "logging": [{}],
+            "object_lock_configuration": [],
+            "replication_configuration": [],
+            "server_side_encryption_configuration": [],
+            "tags_all": {},
+            "versioning": [],
+            "website": []
+          }
+        },
+        {
+          "address": "aws_s3_bucket.validbucket2[0]",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "validbucket2",
+          "index": 0,
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "bucket": "validbucket2-mtu721uc",
+            "force_destroy": true,
+            "tags": null,
+            "timeouts": null
+          },
+          "sensitive_values": {
+            "cors_rule": [],
+            "grant": [],
+            "lifecycle_rule": [],
+            "logging": [],
+            "object_lock_configuration": [],
+            "replication_configuration": [],
+            "server_side_encryption_configuration": [],
+            "tags_all": {},
+            "versioning": [],
+            "website": []
+          }
+        },
+        {
+          "address": "aws_s3_bucket_acl.acl1",
+          "mode": "managed",
+          "type": "aws_s3_bucket_acl",
+          "name": "acl1",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "acl": "log-delivery-write",
+            "expected_bucket_owner": null
+          },
+          "sensitive_values": { "access_control_policy": [] }
+        },
+        {
+          "address": "aws_s3_bucket_logging.s3_bucket_log[0]",
+          "mode": "managed",
+          "type": "aws_s3_bucket_logging",
+          "name": "s3_bucket_log",
+          "index": 0,
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "expected_bucket_owner": null,
+            "target_grant": [],
+            "target_object_key_format": [],
+            "target_prefix": ""
+          },
+          "sensitive_values": {
+            "target_grant": [],
+            "target_object_key_format": []
+          }
+        },
+        {
+          "address": "aws_s3_bucket_ownership_controls.logbucket1-acl-controls",
+          "mode": "managed",
+          "type": "aws_s3_bucket_ownership_controls",
+          "name": "logbucket1-acl-controls",
+          "provider_name": "registry.terraform.io/hashicorp/aws",
+          "schema_version": 0,
+          "values": {
+            "rule": [{ "object_ownership": "BucketOwnerPreferred" }]
+          },
+          "sensitive_values": { "rule": [{}] }
+        }
+      ]
+    }
+  },
+  "resource_changes": [
+    {
+      "address": "aws_s3_bucket.logbucket1",
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "logbucket1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "bucket": "logbucket1-mtu721uc",
+          "force_destroy": true,
+          "tags": null,
+          "timeouts": null
+        },
+        "after_unknown": {
+          "acceleration_status": true,
+          "acl": true,
+          "arn": true,
+          "bucket_domain_name": true,
+          "bucket_prefix": true,
+          "bucket_regional_domain_name": true,
+          "cors_rule": true,
+          "grant": true,
+          "hosted_zone_id": true,
+          "id": true,
+          "lifecycle_rule": true,
+          "logging": true,
+          "object_lock_configuration": true,
+          "object_lock_enabled": true,
+          "policy": true,
+          "region": true,
+          "replication_configuration": true,
+          "request_payer": true,
+          "server_side_encryption_configuration": true,
+          "tags_all": true,
+          "versioning": true,
+          "website": true,
+          "website_domain": true,
+          "website_endpoint": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "cors_rule": [],
+          "grant": [],
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "replication_configuration": [],
+          "server_side_encryption_configuration": [],
+          "tags_all": {},
+          "versioning": [],
+          "website": []
+        }
+      }
+    },
+    {
+      "address": "aws_s3_bucket.validbucket1[0]",
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "validbucket1",
+      "index": 0,
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "bucket": "validbucket1-mtu721uc",
+          "force_destroy": true,
+          "logging": [{ "target_prefix": "log/" }],
+          "tags": null,
+          "timeouts": null
+        },
+        "after_unknown": {
+          "acceleration_status": true,
+          "acl": true,
+          "arn": true,
+          "bucket_domain_name": true,
+          "bucket_prefix": true,
+          "bucket_regional_domain_name": true,
+          "cors_rule": true,
+          "grant": true,
+          "hosted_zone_id": true,
+          "id": true,
+          "lifecycle_rule": true,
+          "logging": [{ "target_bucket": true }],
+          "object_lock_configuration": true,
+          "object_lock_enabled": true,
+          "policy": true,
+          "region": true,
+          "replication_configuration": true,
+          "request_payer": true,
+          "server_side_encryption_configuration": true,
+          "tags_all": true,
+          "versioning": true,
+          "website": true,
+          "website_domain": true,
+          "website_endpoint": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "cors_rule": [],
+          "grant": [],
+          "lifecycle_rule": [],
+          "logging": [{}],
+          "object_lock_configuration": [],
+          "replication_configuration": [],
+          "server_side_encryption_configuration": [],
+          "tags_all": {},
+          "versioning": [],
+          "website": []
+        }
+      }
+    },
+    {
+      "address": "aws_s3_bucket.validbucket2[0]",
+      "mode": "managed",
+      "type": "aws_s3_bucket",
+      "name": "validbucket2",
+      "index": 0,
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "bucket": "validbucket2-mtu721uc",
+          "force_destroy": true,
+          "tags": null,
+          "timeouts": null
+        },
+        "after_unknown": {
+          "acceleration_status": true,
+          "acl": true,
+          "arn": true,
+          "bucket_domain_name": true,
+          "bucket_prefix": true,
+          "bucket_regional_domain_name": true,
+          "cors_rule": true,
+          "grant": true,
+          "hosted_zone_id": true,
+          "id": true,
+          "lifecycle_rule": true,
+          "logging": true,
+          "object_lock_configuration": true,
+          "object_lock_enabled": true,
+          "policy": true,
+          "region": true,
+          "replication_configuration": true,
+          "request_payer": true,
+          "server_side_encryption_configuration": true,
+          "tags_all": true,
+          "versioning": true,
+          "website": true,
+          "website_domain": true,
+          "website_endpoint": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "cors_rule": [],
+          "grant": [],
+          "lifecycle_rule": [],
+          "logging": [],
+          "object_lock_configuration": [],
+          "replication_configuration": [],
+          "server_side_encryption_configuration": [],
+          "tags_all": {},
+          "versioning": [],
+          "website": []
+        }
+      }
+    },
+    {
+      "address": "aws_s3_bucket_acl.acl1",
+      "mode": "managed",
+      "type": "aws_s3_bucket_acl",
+      "name": "acl1",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": { "acl": "log-delivery-write", "expected_bucket_owner": null },
+        "after_unknown": {
+          "access_control_policy": true,
+          "bucket": true,
+          "id": true
+        },
+        "before_sensitive": false,
+        "after_sensitive": { "access_control_policy": [] }
+      }
+    },
+    {
+      "address": "aws_s3_bucket_logging.s3_bucket_log[0]",
+      "mode": "managed",
+      "type": "aws_s3_bucket_logging",
+      "name": "s3_bucket_log",
+      "index": 0,
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": {
+          "expected_bucket_owner": null,
+          "target_grant": [],
+          "target_object_key_format": [],
+          "target_prefix": ""
+        },
+        "after_unknown": {
+          "bucket": true,
+          "id": true,
+          "target_bucket": true,
+          "target_grant": [],
+          "target_object_key_format": []
+        },
+        "before_sensitive": false,
+        "after_sensitive": {
+          "target_grant": [],
+          "target_object_key_format": []
+        }
+      }
+    },
+    {
+      "address": "aws_s3_bucket_ownership_controls.logbucket1-acl-controls",
+      "mode": "managed",
+      "type": "aws_s3_bucket_ownership_controls",
+      "name": "logbucket1-acl-controls",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create"],
+        "before": null,
+        "after": { "rule": [{ "object_ownership": "BucketOwnerPreferred" }] },
+        "after_unknown": { "bucket": true, "id": true, "rule": [{}] },
+        "before_sensitive": false,
+        "after_sensitive": { "rule": [{}] }
+      }
+    }
+  ],
+  "configuration": {
+    "provider_config": {
+      "aws": {
+        "name": "aws",
+        "full_name": "registry.terraform.io/hashicorp/aws",
+        "expressions": { "region": { "constant_value": "us-west-1" } }
+      }
+    },
+    "root_module": {
+      "resources": [
+        {
+          "address": "aws_s3_bucket.logbucket1",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "logbucket1",
+          "provider_config_key": "aws",
+          "expressions": {
+            "bucket": { "constant_value": "logbucket1-mtu721uc" },
+            "force_destroy": { "constant_value": true }
+          },
+          "schema_version": 0
+        },
+        {
+          "address": "aws_s3_bucket.validbucket1",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "validbucket1",
+          "provider_config_key": "aws",
+          "expressions": {
+            "bucket": { "constant_value": "validbucket1-mtu721uc" },
+            "force_destroy": { "constant_value": true },
+            "logging": [
+              {
+                "target_bucket": {
+                  "references": [
+                    "aws_s3_bucket.logbucket1.id",
+                    "aws_s3_bucket.logbucket1"
+                  ]
+                },
+                "target_prefix": { "constant_value": "log/" }
+              }
+            ]
+          },
+          "schema_version": 0,
+          "count_expression": { "references": ["local.create_bucket"] }
+        },
+        {
+          "address": "aws_s3_bucket.validbucket2",
+          "mode": "managed",
+          "type": "aws_s3_bucket",
+          "name": "validbucket2",
+          "provider_config_key": "aws",
+          "expressions": {
+            "bucket": { "constant_value": "validbucket2-mtu721uc" },
+            "force_destroy": { "constant_value": true }
+          },
+          "schema_version": 0,
+          "count_expression": { "references": ["local.create_bucket"] }
+        },
+        {
+          "address": "aws_s3_bucket_acl.acl1",
+          "mode": "managed",
+          "type": "aws_s3_bucket_acl",
+          "name": "acl1",
+          "provider_config_key": "aws",
+          "expressions": {
+            "acl": { "constant_value": "log-delivery-write" },
+            "bucket": {
+              "references": [
+                "aws_s3_bucket.logbucket1.id",
+                "aws_s3_bucket.logbucket1"
+              ]
+            }
+          },
+          "schema_version": 0,
+          "depends_on": [
+            "aws_s3_bucket_ownership_controls.logbucket1-acl-controls"
+          ]
+        },
+        {
+          "address": "aws_s3_bucket_logging.s3_bucket_log",
+          "mode": "managed",
+          "type": "aws_s3_bucket_logging",
+          "name": "s3_bucket_log",
+          "provider_config_key": "aws",
+          "expressions": {
+            "bucket": {
+              "references": [
+                "aws_s3_bucket.validbucket2[0].id",
+                "aws_s3_bucket.validbucket2[0]",
+                "aws_s3_bucket.validbucket2"
+              ]
+            },
+            "target_bucket": {
+              "references": [
+                "aws_s3_bucket.logbucket1.id",
+                "aws_s3_bucket.logbucket1"
+              ]
+            },
+            "target_prefix": { "constant_value": "" }
+          },
+          "schema_version": 0,
+          "count_expression": { "references": ["local.create_bucket"] }
+        },
+        {
+          "address": "aws_s3_bucket_ownership_controls.logbucket1-acl-controls",
+          "mode": "managed",
+          "type": "aws_s3_bucket_ownership_controls",
+          "name": "logbucket1-acl-controls",
+          "provider_config_key": "aws",
+          "expressions": {
+            "bucket": {
+              "references": [
+                "aws_s3_bucket.logbucket1.id",
+                "aws_s3_bucket.logbucket1"
+              ]
+            },
+            "rule": [
+              {
+                "object_ownership": { "constant_value": "BucketOwnerPreferred" }
+              }
+            ]
+          },
+          "schema_version": 0
+        }
+      ],
+      "variables": {
+        "create_bucket": {
+          "default": true,
+          "description": "Controls if S3 bucket should be created"
+        }
+      }
+    }
+  },
+  "relevant_attributes": [
+    { "resource": "aws_s3_bucket.logbucket1", "attribute": ["id"] },
+    { "resource": "aws_s3_bucket.validbucket2[0]", "attribute": ["id"] }
+  ]
+}

--- a/pkg/input/tfplan_test.go
+++ b/pkg/input/tfplan_test.go
@@ -88,3 +88,32 @@ func TestTfPlanDetectorNotYAML(t *testing.T) {
 	assert.True(t, errors.Is(err, input.FailedToParseInput))
 	assert.Nil(t, tfplan)
 }
+
+func TestFilterReferences(t *testing.T) {
+	type test struct {
+		input    []string
+		expected []string
+	}
+
+	tests := []test{
+		{
+			input: []string{
+				"aws_s3_bucket.bucket.id",
+				"aws_s3_bucket.bucket",
+			},
+			expected: []string{"aws_s3_bucket.bucket"},
+		},
+		{
+			input: []string{
+				"aws_s3_bucket.bucket[0].id",
+				"aws_s3_bucket.bucket[0]",
+				"aws_s3_bucket.bucket",
+			},
+			expected: []string{"aws_s3_bucket.bucket[0]"},
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, input.TfPlanFilterReferences(test.input), test.expected)
+	}
+}


### PR DESCRIPTION
Filtering tfplan references to properly consider counts

Before the change (Actual):
<img width="757" alt="image" src="https://github.com/snyk/policy-engine/assets/119867733/e787a9d6-ac05-497c-9cff-8906e5e3a1e9">


[Jira ticket IAC-2907](https://snyksec.atlassian.net/browse/IAC-2907)