### PR TITLE
fix: increase default timeouts - for query and init [IAC-2863]

### DIFF
--- a/changes/unreleased/Fixed-20240401-193914.yaml
+++ b/changes/unreleased/Fixed-20240401-193914.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: increase default timeouts - for query and init
+time: 2024-04-01T19:39:14.602353+03:00

--- a/pkg/engine/engine.go
+++ b/pkg/engine/engine.go
@@ -31,9 +31,9 @@ import (
 )
 
 const (
-	DefaultInitTimeout  = 30 * time.Second
+	DefaultInitTimeout  = 60 * time.Second
 	DefaultEvalTimeout  = 5 * time.Minute
-	DefaultQueryTimeout = 45 * time.Second
+	DefaultQueryTimeout = 60 * time.Second
 )
 
 // Engine is responsible for evaluating some States with a given set of rules.


### PR DESCRIPTION
Increasing default timeouts - for query and init

We get for CCPE in the last period of time frequent timeout errors on the PE initialization - this PR is an attempt to address that.

Is hard to determine on CCPE side what might be the cause (e.g. my guess is that we have some customers that also have custom rules) because we lack the org id for the temporal workflow that is running.

Logs linked to this: [here](https://app.datadoghq.com/logs?query=%40polaris.instance%3Apolaris-prod-mt-gcp-1%20service%3A%28cloud-config-policy-engine-workflow-runner-bo%20OR%20cloud-config-policy-engine-workflow-runner-fo%29%20%40cloud-config-policy-engine-workflow-runner.Error%3A%22analyze%3A%201%20error%20occurred%3A%0A%09%2A%20initialization%20timed%20out%0A%0A%22&cols=host%2Cservice&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1710693531060&to_ts=1711989531060&live=true)

[Jira Ticket IAC-2863](https://snyksec.atlassian.net/browse/IAC-2863)