### PR TITLE
fix: account for multiple chars in resource id[IAC-3015]

### DIFF
--- a/changes/unreleased/Fixed-20240725-160823.yaml
+++ b/changes/unreleased/Fixed-20240725-160823.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: fix location computation for resources with multi-char ID inside square brackets
+time: 2024-07-25T16:08:23.452724+03:00

--- a/pkg/hcl_interpreter/source_locations.go
+++ b/pkg/hcl_interpreter/source_locations.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Utility to strip out "[x]" parts from resource IDs.
-var resourceIdBracketPattern = regexp.MustCompile(`\[[^[*]\]`)
+var resourceIdBracketPattern = regexp.MustCompile(`\[[^[*]+\]`)
 
 func (v *Evaluation) Location(
 	resourceId string,

--- a/pkg/input/golden_location_test.go
+++ b/pkg/input/golden_location_test.go
@@ -399,6 +399,41 @@ var goldenLocationTests = []goldenLocationTest{
 					},
 				},
 			},
+			{
+				path: []interface{}{
+					"golden_test/tf/count-simple",
+					"aws_s3_bucket",
+					"aws_s3_bucket.example[10]", // test also double digit resource id
+					"bucket_prefix",
+				},
+				expected: LocationStack{
+					{
+						Path: "main.tf",
+						Line: 17,
+						Col:  3,
+					},
+				},
+			},
+		},
+	},
+	{
+		directory: "golden_test/tf/for-each",
+		cases: []goldenLocationTestCase{
+			{
+				path: []interface{}{
+					"golden_test/tf/for-each",
+					"aws_s3_bucket",
+					"aws_s3_bucket.mybuckets[prodabc123]",
+					"bucket_prefix",
+				},
+				expected: LocationStack{
+					{
+						Path: "main.tf",
+						Line: 27,
+						Col:  3,
+					},
+				},
+			},
 		},
 	},
 }

--- a/pkg/input/golden_test/tf/count-simple.json
+++ b/pkg/input/golden_test/tf/count-simple.json
@@ -17,6 +17,15 @@
           "bucket_prefix": "example_0"
         }
       },
+      "aws_s3_bucket.example[10]": {
+        "id": "aws_s3_bucket.example[10]",
+        "resource_type": "aws_s3_bucket",
+        "namespace": "golden_test/tf/count-simple/main.tf",
+        "meta": {},
+        "attributes": {
+          "bucket_prefix": "example_10"
+        }
+      },
       "aws_s3_bucket.example[1]": {
         "id": "aws_s3_bucket.example[1]",
         "resource_type": "aws_s3_bucket",
@@ -33,6 +42,69 @@
         "meta": {},
         "attributes": {
           "bucket_prefix": "example_2"
+        }
+      },
+      "aws_s3_bucket.example[3]": {
+        "id": "aws_s3_bucket.example[3]",
+        "resource_type": "aws_s3_bucket",
+        "namespace": "golden_test/tf/count-simple/main.tf",
+        "meta": {},
+        "attributes": {
+          "bucket_prefix": "example_3"
+        }
+      },
+      "aws_s3_bucket.example[4]": {
+        "id": "aws_s3_bucket.example[4]",
+        "resource_type": "aws_s3_bucket",
+        "namespace": "golden_test/tf/count-simple/main.tf",
+        "meta": {},
+        "attributes": {
+          "bucket_prefix": "example_4"
+        }
+      },
+      "aws_s3_bucket.example[5]": {
+        "id": "aws_s3_bucket.example[5]",
+        "resource_type": "aws_s3_bucket",
+        "namespace": "golden_test/tf/count-simple/main.tf",
+        "meta": {},
+        "attributes": {
+          "bucket_prefix": "example_5"
+        }
+      },
+      "aws_s3_bucket.example[6]": {
+        "id": "aws_s3_bucket.example[6]",
+        "resource_type": "aws_s3_bucket",
+        "namespace": "golden_test/tf/count-simple/main.tf",
+        "meta": {},
+        "attributes": {
+          "bucket_prefix": "example_6"
+        }
+      },
+      "aws_s3_bucket.example[7]": {
+        "id": "aws_s3_bucket.example[7]",
+        "resource_type": "aws_s3_bucket",
+        "namespace": "golden_test/tf/count-simple/main.tf",
+        "meta": {},
+        "attributes": {
+          "bucket_prefix": "example_7"
+        }
+      },
+      "aws_s3_bucket.example[8]": {
+        "id": "aws_s3_bucket.example[8]",
+        "resource_type": "aws_s3_bucket",
+        "namespace": "golden_test/tf/count-simple/main.tf",
+        "meta": {},
+        "attributes": {
+          "bucket_prefix": "example_8"
+        }
+      },
+      "aws_s3_bucket.example[9]": {
+        "id": "aws_s3_bucket.example[9]",
+        "resource_type": "aws_s3_bucket",
+        "namespace": "golden_test/tf/count-simple/main.tf",
+        "meta": {},
+        "attributes": {
+          "bucket_prefix": "example_9"
         }
       }
     }

--- a/pkg/input/golden_test/tf/count-simple/main.tf
+++ b/pkg/input/golden_test/tf/count-simple/main.tf
@@ -13,6 +13,6 @@
 # limitations under the License.
 
 resource "aws_s3_bucket" "example" {
-  count         = 3
+  count         = 11
   bucket_prefix = "example_${count.index}"
 }


### PR DESCRIPTION
When computing a resource location a regex is used to strip the brackets from a resource ID.
E.g. `aws_s3_bucket.example[1]` stripped of brackets is  `aws_s3_bucket.example`

The regex used was not working when an ID had multiple chars inside brackets.