### PR TITLE
feat: support for user-defined policy output [IAC-3161]

### DIFF
--- a/changes/unreleased/Added-20241128-171516.yaml
+++ b/changes/unreleased/Added-20241128-171516.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: support for a user-defined free form output for the single-resource and multi-resource policy types
+time: 2024-11-28T17:15:16.982698+02:00

--- a/docs/policy_spec.md
+++ b/docs/policy_spec.md
@@ -285,6 +285,7 @@ The `info` return value is set to an object that describes a single resource and
 optionally:
 * Its attributes that contributed to the policy result
 * Its relation to the primary resource associated with the policy result
+* User defined policy output (see [examples/12-context.rego](../examples/12-context.rego))
 
 #### `info` object properties
 
@@ -294,6 +295,7 @@ optionally:
 | `primary_resource` | object | The primary [resource object](#resource-objects) associated with a policy result             |
 | `attributes`       | array  | An array of [attribute paths](#attribute-paths) from the resource in the `resource` property |
 | `correlation`      | string | A manually-specified [correlation ID](#correlation-ids)                                      |
+| `context`          | object | User defined policy output ([example](../examples/12-context.rego))                                                                  |
 
 #### Correlation IDs
 

--- a/examples/12-context.rego
+++ b/examples/12-context.rego
@@ -1,0 +1,31 @@
+# This example showcases the use of the `context` field in the `info` object to
+# provide user-defined policy output.
+
+# The `context` field is a dictionary of values that can be used to provide
+# additional information about the policy.
+
+# Here the context is used in single-resource policy, but it can be used
+# in multi-resource policies as well.
+package rules.snyk_012.tf
+
+resource_type = "aws_s3_bucket"
+
+has_bucket_name {
+	is_string(input.bucket)
+	contains(input.bucket, "bucket")
+}
+
+deny[info] {
+	has_bucket_name
+	info := {"message": "Bucket names should not contain the word bucket, it's implied"}
+}
+
+# The `context` field is provided via the `info` object returned by the
+# (optional) `resources` rule.
+resources[info] {
+  info := {
+    "context": {
+      "bucket_name": input.bucket,
+    }
+  }
+}

--- a/pkg/policy/base.go
+++ b/pkg/policy/base.go
@@ -449,11 +449,12 @@ type policyResult struct {
 }
 
 type resourcesResult struct {
-	Resource        *policyResultResource `json:"resource" rego:"resource"`
-	PrimaryResource *policyResultResource `json:"primary_resource" rego:"primary_resource"`
-	Attributes      [][]interface{}       `json:"attributes" rego:"attributes"`
-	Correlation     string                `json:"correlation" rego:"correlation"`
-	ResourceType    string                `json:"resource_type" rego:"resource_type"`
+	Resource        *policyResultResource  `json:"resource" rego:"resource"`
+	PrimaryResource *policyResultResource  `json:"primary_resource" rego:"primary_resource"`
+	Attributes      [][]interface{}        `json:"attributes" rego:"attributes"`
+	Correlation     string                 `json:"correlation" rego:"correlation"`
+	ResourceType    string                 `json:"resource_type" rego:"resource_type"`
+	Context         map[string]interface{} `json:"context" rego:"context"`
 }
 
 // Helper for unique resource identifiers, meant to be used as key in a `map`.

--- a/pkg/policy/fugue.go
+++ b/pkg/policy/fugue.go
@@ -44,6 +44,10 @@ func (b *fugueAllowBooleanProcessor) Process(val ast.Value) error {
 	return rego.Bind(val, &b.allow)
 }
 
+func (b *fugueAllowBooleanProcessor) ProcessResource(val ast.Value) error {
+	return nil
+}
+
 func (b *fugueAllowBooleanProcessor) Results() []models.RuleResult {
 	return []models.RuleResult{
 		{
@@ -75,6 +79,10 @@ func NewFugueDenyBooleanProcessor(
 
 func (b *fugueDenyBooleanProcessor) Process(val ast.Value) error {
 	return rego.Bind(val, &b.deny)
+}
+
+func (b *fugueDenyBooleanProcessor) ProcessResource(val ast.Value) error {
+	return nil
 }
 
 func (b *fugueDenyBooleanProcessor) Results() []models.RuleResult {
@@ -161,6 +169,10 @@ func (b *fugueAllowInfoProcessor) Process(val ast.Value) error {
 		ResourceNamespace: b.resource.Namespace,
 		Severity:          b.severity,
 	})
+	return nil
+}
+
+func (p *fugueAllowInfoProcessor) ProcessResource(val ast.Value) error {
 	return nil
 }
 

--- a/pkg/policy/multi.go
+++ b/pkg/policy/multi.go
@@ -187,6 +187,7 @@ func (p *multiDenyProcessor) ProcessResource(val ast.Value) error {
 		p.builders[correlation].severity = p.metadata.Severity
 		p.builders[correlation].remediation = p.defaultRemediation
 	}
+	p.builders[correlation].addContext(result.Context)
 	if result.ResourceType != "" {
 		p.builders[correlation].setMissingResourceType(result.ResourceType)
 	}

--- a/pkg/policy/ruleresultbuilder.go
+++ b/pkg/policy/ruleresultbuilder.go
@@ -129,6 +129,19 @@ func (builder *ruleResultBuilder) addGraph(edges []policyResultEdge) *ruleResult
 	return builder
 }
 
+func (builder *ruleResultBuilder) addContext(context map[string]interface{}) *ruleResultBuilder {
+	if len(context) == 0 {
+		return builder
+	}
+	if builder.context == nil {
+		builder.context = map[string]interface{}{}
+	}
+	for k, v := range context {
+		builder.context[k] = v
+	}
+	return builder
+}
+
 func (builder *ruleResultBuilder) toRuleResult() models.RuleResult {
 	// Gather resources.
 	resourceKeys := []ResourceKey{}

--- a/test/examples.json
+++ b/test/examples.json
@@ -2105,6 +2105,164 @@
             }
           ],
           "package": "data.rules.snyk_011.tf"
+        },
+        {
+          "kind": "vulnerability",
+          "rule_bundle": {
+            "source": "data"
+          },
+          "resource_types": [
+            "aws_s3_bucket"
+          ],
+          "results": [
+            {
+              "passed": true,
+              "ignored": false,
+              "resource_id": "aws_s3_bucket.aes_bucket",
+              "resource_namespace": "../examples/main.tf",
+              "resource_type": "aws_s3_bucket",
+              "context": {
+                "bucket_name": "i-use-aes-encryption"
+              },
+              "resources": [
+                {
+                  "id": "aws_s3_bucket.aes_bucket",
+                  "type": "aws_s3_bucket",
+                  "namespace": "../examples/main.tf",
+                  "location": [
+                    {
+                      "filepath": "../examples/main.tf",
+                      "line": 57,
+                      "column": 1
+                    }
+                  ],
+                  "attributes": [
+                    {
+                      "path": [
+                        "bucket"
+                      ],
+                      "location": {
+                        "filepath": "../examples/main.tf",
+                        "line": 58,
+                        "column": 3
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "passed": false,
+              "ignored": false,
+              "message": "Bucket names should not contain the word bucket, it's implied",
+              "resource_id": "aws_s3_bucket.bucket1",
+              "resource_namespace": "../examples/main.tf",
+              "resource_type": "aws_s3_bucket",
+              "context": {
+                "bucket_name": "dumb-bucket"
+              },
+              "resources": [
+                {
+                  "id": "aws_s3_bucket.bucket1",
+                  "type": "aws_s3_bucket",
+                  "namespace": "../examples/main.tf",
+                  "location": [
+                    {
+                      "filepath": "../examples/main.tf",
+                      "line": 5,
+                      "column": 1
+                    }
+                  ],
+                  "attributes": [
+                    {
+                      "path": [
+                        "bucket"
+                      ],
+                      "location": {
+                        "filepath": "../examples/main.tf",
+                        "line": 6,
+                        "column": 3
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "passed": true,
+              "ignored": false,
+              "resource_id": "aws_s3_bucket.bucket2",
+              "resource_namespace": "../examples/main.tf",
+              "resource_type": "aws_s3_bucket",
+              "context": {
+                "bucket_name": "dumb"
+              },
+              "resources": [
+                {
+                  "id": "aws_s3_bucket.bucket2",
+                  "type": "aws_s3_bucket",
+                  "namespace": "../examples/main.tf",
+                  "location": [
+                    {
+                      "filepath": "../examples/main.tf",
+                      "line": 9,
+                      "column": 1
+                    }
+                  ],
+                  "attributes": [
+                    {
+                      "path": [
+                        "bucket"
+                      ],
+                      "location": {
+                        "filepath": "../examples/main.tf",
+                        "line": 10,
+                        "column": 3
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "passed": false,
+              "ignored": false,
+              "message": "Bucket names should not contain the word bucket, it's implied",
+              "resource_id": "aws_s3_bucket.bucket3",
+              "resource_namespace": "../examples/main.tf",
+              "resource_type": "aws_s3_bucket",
+              "context": {
+                "bucket_name": "bucket3"
+              },
+              "resources": [
+                {
+                  "id": "aws_s3_bucket.bucket3",
+                  "type": "aws_s3_bucket",
+                  "namespace": "../examples/main.tf",
+                  "location": [
+                    {
+                      "filepath": "../examples/main.tf",
+                      "line": 37,
+                      "column": 1
+                    }
+                  ],
+                  "attributes": [
+                    {
+                      "path": [
+                        "bucket"
+                      ],
+                      "location": {
+                        "filepath": "../examples/main.tf",
+                        "line": 38,
+                        "column": 3
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "package": "data.rules.snyk_012.tf"
         }
       ]
     }


### PR DESCRIPTION
Added support for a user-defined free form output for the single-resource and multi-resource policy types.

Potential use case: providing customized evidence based on resource values in policy "passed" outputs.

See `examples/12-context.rego` 