### PR TITLE
Bump version to v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
 
+
+## v0.34.0 - 2025-05-19
+### Changed
+* upgrade to opa v1.4.2 from v0.69.0
+
 ## v0.33.3 - 2025-03-10
 ### Security
 * update golang.org/x/net to v0.37.0

--- a/changes/unreleased/Changed-20250513-154933.yaml
+++ b/changes/unreleased/Changed-20250513-154933.yaml
@@ -1,3 +1,0 @@
-kind: Changed
-body: upgrade to opa v1.4.2 from v0.69.0
-time: 2025-05-13T15:49:33.417828+03:00

--- a/changes/v0.34.0.md
+++ b/changes/v0.34.0.md
@@ -1,0 +1,3 @@
+## v0.34.0 - 2025-05-19
+### Changed
+* upgrade to opa v1.4.2 from v0.69.0


### PR DESCRIPTION
Breaking changes are introduced

Rego rules need to be upgraded in order to work with policy-engine