### PR TITLE
chore: update codeowners [PRODSEC-10215]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/iac @snyk/infrasec_iac
+* @snyk/iac @snyk/infrasec_iac @snyk/code_code-iac-secrets

--- a/changes/unreleased/Changed-20260416-162702.yaml
+++ b/changes/unreleased/Changed-20260416-162702.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Codeowners
+time: 2026-04-16T16:27:02.821697+03:00


### PR DESCRIPTION
Updates codeowners to append the new github governance managed teams.
For more information, please check:
- https://snyksec.atlassian.net/wiki/spaces/PRODSEC/pages/4613570586/Updates+to+CODEOWNERS+and+repository+collaborators+to+match+organisation+change
[!IMPORTANT]:
If this service relies on vervet, you will need to run a command to regenerate the spec (e.g. `make generate`) before merging it.
The best option is to:
- checkout the branch `update-ownership-PRODSEC-10215-hjbl`
- run the command
- commit and push the results to this PR before you approve and merge it.