### PR TITLE
chore: add prodsec-orb-runtime context to config.yaml [PRODSEC-10643]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,8 +23,10 @@ workflows:
           name: Scan repository for secrets
           context:
             - snyk-bot-slack
+            - prodsec-orb-runtime
           channel: snyk-vuln-alerts-iac
       - security-scans:
           name: Security Scans
           context:
             - analysis-iac
+            - prodsec-orb-runtime

--- a/changes/unreleased/Changed-20260731-131949.yaml
+++ b/changes/unreleased/Changed-20260731-131949.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: config.yml
+time: 2026-07-31T13:19:49.807448-04:00


### PR DESCRIPTION
## Summary
This PR adds the `prodsec-orb-runtime` context to jobs and workflows that use prodsec-orb commands.

## Changes
- Added `prodsec-orb-runtime` context to jobs using:
  - `prodsec/secrets-scan`
  - `prodsec/security_scans`
  - `prodsec/container_scan`
  - `publish/publish`

## Related
PRODSEC-10643
